### PR TITLE
Added hyphen/backslash to .yml

### DIFF
--- a/dbt_coves/templates/source_model_props.yml
+++ b/dbt_coves/templates/source_model_props.yml
@@ -15,7 +15,7 @@ models:
     columns:
 {%- for cols in nested.values() %}
   {%- for col in cols %}
-      - name: {{ col.lower().replace(" ","_").replace(":","_").replace("(","_").replace(")","_") }}
+      - name: {{ col.lower().replace(" ","_").replace(":","_").replace("(","_").replace(")","_").replace("-","_").replace("/","_") }}
   {%- endfor %}
 {%- endfor %}
 {%- for col in columns %}


### PR DESCRIPTION
This was missed in my original PR - YML needs to have the same replacement as SQL does, in order to match columns.
This did not error in dbt; but failed precommit