### PR TITLE
feat/751-dbtcoves-requiring-config-folder

### DIFF
--- a/dbt_coves/tasks/setup/dbt.py
+++ b/dbt_coves/tasks/setup/dbt.py
@@ -8,8 +8,8 @@ from rich.console import Console
 from dbt_coves.config.config import DbtCovesConfig
 from dbt_coves.tasks.base import NonDbtBaseTask
 from dbt_coves.utils.jinja import render_template
-from dbt_coves.utils.shell import run, run_and_capture_cwd
-from .utils import print_row
+from dbt_coves.utils.shell import run_and_capture_cwd
+from .utils import print_row, file_exists
 
 
 console = Console()
@@ -32,21 +32,23 @@ class SetupDbtTask(NonDbtBaseTask):
 
     @classmethod
     def run(cls) -> int:
-        config_folder = cls.get_config_folder()
+        config_folder = cls.get_config_folder(mandatory=False)
         context = cls.get_dbt_profiles_context(config_folder)
         cls.dbt_init(config_folder)
         cls.dbt_debug(config_folder)
         return 0
 
     @classmethod
-    def get_config_folder(cls):
+    def get_config_folder(cls, mandatory=True):
         workspace_path = os.environ.get("WORKSPACE_PATH", Path.cwd())
-        return DbtCovesConfig.get_config_folder(workspace_path=workspace_path)
+        return DbtCovesConfig.get_config_folder(
+            workspace_path=workspace_path, mandatory=mandatory
+        )
 
     @classmethod
     def get_dbt_profiles_context(cls, config_folder=None):
         if not config_folder:
-            config_folder = cls.get_config_folder()
+            config_folder = cls.get_config_folder(mandatory=False)
         profiles_status = "[red]MISSING[/red]"
         default_dbt_path = Path("~/.dbt").expanduser()
         dbt_path = os.environ.get("DBT_PROFILES_DIR", default_dbt_path)
@@ -93,11 +95,17 @@ class SetupDbtTask(NonDbtBaseTask):
     @classmethod
     def dbt_debug(cls, config_folder=None):
         if not config_folder:
-            config_folder = cls.get_config_folder()
+            config_folder = cls.get_config_folder(mandatory=False)
+            if config_folder:
+                dbt_project_yaml_path = Path(config_folder.parent) / "dbt_project.yml"
+            else:
+                dbt_project_yaml_path = file_exists(
+                    Path(os.getcwd()), "dbt_project.yml"
+                )
         debug_status = "[red]FAIL[/red]"
         console.print("\n")
 
-        output = run(["dbt", "debug"], cwd=config_folder.parent)
+        output = run_and_capture_cwd(["dbt", "debug"], dbt_project_yaml_path.parent)
 
         if output.returncode is 0:
             debug_status = "[green]SUCCESS :heavy_check_mark:[/green]"
@@ -112,11 +120,13 @@ class SetupDbtTask(NonDbtBaseTask):
     @classmethod
     def dbt_init(cls, config_folder=None):
         if not config_folder:
-            config_folder = cls.get_config_folder()
-        dbt_project_yaml_path = Path(config_folder.parent) / "dbt_project.yml"
-
-        if not dbt_project_yaml_path.exists():
-            output = run_and_capture_cwd(["dbt", "init"], cwd=config_folder.parent)
+            config_folder = cls.get_config_folder(mandatory=False)
+            if config_folder:
+                dbt_project_yaml_path = Path(config_folder.parent) / "dbt_project.yml"
+            else:
+                dbt_project_yaml_path = file_exists(Path.cwd(), "dbt_project.yml")
+        if not dbt_project_yaml_path:
+            output = run_and_capture_cwd(["dbt", "init"], Path.cwd())
 
             if output.returncode is 0:
                 init_status = "[green]SUCCESS :heavy_check_mark:[/green]"
@@ -140,27 +150,32 @@ class SetupDbtTask(NonDbtBaseTask):
     @classmethod
     def dbt_deps(cls, config_folder=None):
         if not config_folder:
-            config_folder = cls.get_config_folder()
-        dbt_project_yaml_path = Path(config_folder.parent) / "dbt_project.yml"
+            config_folder = cls.get_config_folder(mandatory=False)
+            if config_folder:
+                dbt_project_yaml_path = Path(config_folder.parent) / "dbt_project.yml"
+            else:
+                dbt_project_yaml_path = file_exists(
+                    Path(os.getcwd()), "dbt_project.yml"
+                )
 
         if dbt_project_yaml_path.exists():
-            output = run_and_capture_cwd(["dbt", "deps"], cwd=config_folder.parent)
+            output = run_and_capture_cwd(["dbt", "deps"], dbt_project_yaml_path.parent)
 
             if output.returncode is 0:
-                init_status = "[green]SUCCESS :heavy_check_mark:[/green]"
+                deps_status = "[green]SUCCESS :heavy_check_mark:[/green]"
             print_row(
                 "dbt deps",
-                init_status,
+                deps_status,
                 new_section=True,
             )
             if output.returncode > 0:
                 raise Exception("dbt deps error. Check logs.")
         else:
-            init_status = (
+            deps_status = (
                 "[green]FOUND :heavy_check_mark:[/green] dbt project not found"
             )
             print_row(
                 "dbt deps",
-                init_status,
+                deps_status,
                 new_section=True,
             )

--- a/dbt_coves/tasks/setup/git.py
+++ b/dbt_coves/tasks/setup/git.py
@@ -98,7 +98,8 @@ class SetupGitTask(NonDbtBaseTask):
             return
 
         if any(os.scandir(workspace_path)):
-            raise Exception(f"Folder '{workspace_path}' is not empty.")
+            console.print(f"Folder '{workspace_path}' is not empty.")
+            return
 
         default_repo_url = os.environ.get("GIT_REPO_URL", "")
         repo_url = questionary.text(

--- a/dbt_coves/tasks/setup/main.py
+++ b/dbt_coves/tasks/setup/main.py
@@ -1,5 +1,7 @@
 from rich.console import Console
 
+from dbt_coves.tasks.setup.git import SetupGitTask
+
 from .all import SetupAllTask
 from .sqlfluff import SetupSqlfluffTask
 from .pre_commit import SetupPrecommitTask
@@ -31,6 +33,7 @@ class SetupTask(NonDbtBaseTask):
             title="dbt-coves setup commands", dest="task"
         )
         SetupAllTask.register_parser(sub_parsers, base_subparser)
+        SetupGitTask.register_parser(sub_parsers, base_subparser)
         SetupDbtTask.register_parser(sub_parsers, base_subparser)
         SetupSSHTask.register_parser(sub_parsers, base_subparser)
         SetupVscodeTask.register_parser(sub_parsers, base_subparser)

--- a/dbt_coves/tasks/setup/pre_commit.py
+++ b/dbt_coves/tasks/setup/pre_commit.py
@@ -36,7 +36,9 @@ class SetupPrecommitTask(NonDbtBaseTask):
 
     def run(self):
         workspace_path = workspace_path = os.environ.get("WORKSPACE_PATH", Path.cwd())
-        config_folder = DbtCovesConfig.get_config_folder(workspace_path=workspace_path)
+        config_folder = DbtCovesConfig.get_config_folder(
+            workspace_path=workspace_path, mandatory=False
+        )
         templates_folder = (
             self.get_config_value("templates") or f"{config_folder}/templates"
         )

--- a/dbt_coves/tasks/setup/ssh.py
+++ b/dbt_coves/tasks/setup/ssh.py
@@ -77,7 +77,9 @@ class SetupSSHTask(NonDbtBaseTask):
                 .lower()
             )
             if action == "provide":
-                ssh_key = questionary.text("Please paste your private SSH key:").ask()
+                ssh_key = questionary.text(
+                    "Please paste your private ECDSA SSH key:"
+                ).ask()
                 with open(key_path_abs, "w") as file:
                     file.write(ssh_key)
 
@@ -100,10 +102,9 @@ class SetupSSHTask(NonDbtBaseTask):
         if ssh_configured:
             return 0
         else:
-            console.print(
-                f"You must first configure you SSH key in your Git server then rerun [i]'dbt-coves setup'[/i]"
+            raise Exception(
+                f"You must first configure you SSH key in your Git server then rerun 'dbt-coves setup'"
             )
-            return 1
 
     @classmethod
     def generate_ecdsa_keys(cls, key_path_abs):

--- a/dbt_coves/tasks/setup/utils.py
+++ b/dbt_coves/tasks/setup/utils.py
@@ -1,3 +1,7 @@
+import glob
+import os
+import sys
+from pathlib import Path
 from rich.console import Console
 from rich.table import Table
 
@@ -21,3 +25,11 @@ def print_row(
     if new_section:
         console.print("\n")
     console.print(grid)
+
+
+def file_exists(root_path, file_name):
+    for file in glob.glob(f"{str(root_path)}/**/{file_name}"):
+        if file:
+            return Path(file)
+        else:
+            return False

--- a/dbt_coves/tasks/setup/vs_code.py
+++ b/dbt_coves/tasks/setup/vs_code.py
@@ -36,7 +36,18 @@ class SetupVscodeTask(NonDbtBaseTask):
     @classmethod
     def run(cls, prev_context=None) -> int:
         workspace_path = os.environ.get("WORKSPACE_PATH", Path.cwd())
-        config_folder = DbtCovesConfig.get_config_folder(workspace_path=workspace_path)
+        config_folder = DbtCovesConfig.get_config_folder(
+            workspace_path=workspace_path, mandatory=False
+        )
+
+        if not config_folder:
+            print_row(
+                "VSCode settings",
+                f"settings weren't generated: .dbt_coves folder not found",
+                new_section=True,
+            )
+            return 0
+
         if not prev_context:
             prev_context = SetupDbtTask.get_dbt_profiles_context(config_folder)
 


### PR DESCRIPTION
- config_folder is no longer mandatory
- setup git no longer fails when folder has content (continues)
- added setup git as a parser ('dbt-coves setup git' was not working)
- fixed 'dbt-coves setup ssh' unexpected behaviour: if user hasn't copied the key to Git, the program raises an exception instead of continuing (by Noel request): `"You must first configure you SSH key in your Git server then rerun 'dbt-coves setup'"`