### PR TITLE
feat/DCV-1162 New variables to be used on generate properties --destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ how the resources are generated.
 
 ```shell
 --destination
-# Where models yml files will be generated, default: 'models/staging/{{schema}}/{{relation}}.yml'
+# Where models yml files will be generated, default: '{{model_folder_path}}/{{model_file_name}}.yml'
 ```
 
 ```shell
@@ -251,7 +251,8 @@ generate:
     templates_folder: ".dbt_coves/templates" # Folder where source generation jinja templates are located. Override default templates creating source_model_props.yml, source_props.yml and source_model.sql under this folder
 
   properties:
-    destination: "models/staging/{{schema}}/{{relation}}.yml" # Where models yml files will be generated
+    destination: "{{model_folder_path}}/{{model_file_name}}.yml" # Where models yml files will be generated
+    # You can specify a different path by declaring it explicitly, i.e.: "models/staging/{{model_file_name}}.yml"
     update-strategy: ask # Action to perform when a property file already exists. Options: update, recreate, fail, ask (per file)
     models: "models/staging" # Model(s) path where 'generate properties' will look for models for generation
 

--- a/dbt_coves/tasks/generate/base.py
+++ b/dbt_coves/tasks/generate/base.py
@@ -123,14 +123,6 @@ class BaseGenerateTask(BaseConfiguredTask):
     def get_config_value(self, key):
         return self.coves_config.integrated["generate"][self.args.task][key]
 
-    def generate_template(self, destination_path, relation):
-        template_context = dict()
-        if "{{schema}}" in destination_path.replace(" ", ""):
-            template_context["schema"] = relation.schema.lower()
-        if "{{relation}}" in destination_path.replace(" ", ""):
-            template_context["relation"] = relation.name.lower()
-        return render_template(destination_path, template_context)
-
     def render_templates(self, relation, columns, destination, options=None, json_cols=None):
         destination.parent.mkdir(parents=True, exist_ok=True)
         context = self.get_templates_context(relation, columns, json_cols)
@@ -199,15 +191,12 @@ class BaseGenerateTask(BaseConfiguredTask):
         templates_folder,
         update_strategy,
         object_type,
-        destination=None,
-        template=None,
+        yml_path,
+        template,
     ):
         strategy_key_update_all = ""
         strategy_key_recreate_all = ""
-
         rel = context["relation"]
-        yml_dest = self.generate_template(destination, rel)
-        yml_path = Path().joinpath(yml_dest)
 
         context["model"] = rel.name.lower()
         if object_type == "models":


### PR DESCRIPTION
- Changed 'model' dbt-ls selector for the newest -s one
- Generate sources and properties now have their own Jinja-tagged variable management (generate_template method no longer at base.py level)
- From above, 'generate properties' one now consumes dbt manifest in order to process {{model_folder_path}} and {{model_file_name}} variables
- Updated README.md