### PR TITLE
feat/DCV-1658 new generate-sources flags, extra fixes

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -27,9 +27,6 @@ jobs:
       - name: run Pre-Commit
         uses: pre-commit/action@v3.0.0
 
-      - name: Install Poetry
-        uses: Gr1N/setup-poetry@v7
-
       - name: Cache Poetry virtualenv
         uses: actions/cache@v1
         id: cache

--- a/README.md
+++ b/README.md
@@ -180,6 +180,21 @@ dbt-coves generate sources -h
 ```
 
 ```console
+--flatten-json-fields
+# Flag: flatten model JSON fields
+```
+
+```console
+--overwrite-staging-models
+# Flag: overwrite existent staging (SQL) files
+```
+
+```console
+--skip-model-props
+# Flag: don't create model's property (yml) files
+```
+
+```console
 --no-prompt
 # Silently generate source dbt models
 ```

--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -34,6 +34,9 @@ class GenerateSourcesModel(BaseModel):
     templates_folder: Optional[str] = ".dbt_coves/templates"
     metadata: Optional[str] = ""
     no_prompt: Optional[bool] = False
+    flatten_json_fields: Optional[bool] = False
+    overwrite_staging_models: Optional[bool] = False
+    skip_model_props: Optional[bool] = False
 
 
 class GenerateMetadataModel(BaseModel):
@@ -49,7 +52,6 @@ class GenerateModel(BaseModel):
     sources: Optional[GenerateSourcesModel] = GenerateSourcesModel()
     properties: Optional[GeneratePropertiesModel] = GeneratePropertiesModel()
     metadata: Optional[GenerateMetadataModel] = GenerateMetadataModel()
-    no_prompt: Optional[bool] = False
 
 
 class ExtractAirbyteModel(BaseModel):
@@ -159,6 +161,9 @@ class DbtCovesConfig:
         "generate.sources.templates_folder",
         "generate.sources.metadata",
         "generate.sources.no_prompt",
+        "generate.sources.flatten_json_fields",
+        "generate.sources.overwrite_staging_models",
+        "generate.sources.skip_model_props",
         "generate.metadata.database",
         "generate.metadata.schemas",
         "generate.metadata.select_relations",

--- a/dbt_coves/tasks/generate/main.py
+++ b/dbt_coves/tasks/generate/main.py
@@ -33,12 +33,6 @@ class GenerateTask(BaseConfiguredTask):
             help="""Generates dbt source and staging files, model property files and extracts
              metadata for tables (used as input for sources and properties)""",
         )
-        gen_subparser.add_argument(
-            "--no-prompt",
-            help="Silently generate dbt-coves resources",
-            action="store_true",
-            default=False,
-        )
         gen_subparser.set_defaults(cls=cls, which="generate")
         sub_parsers = gen_subparser.add_subparsers(title="dbt-coves generate commands", dest="task")
 

--- a/dbt_coves/utils/flags.py
+++ b/dbt_coves/utils/flags.py
@@ -46,6 +46,9 @@ class DbtCovesFlags:
                 "templates_folder": None,
                 "metadata": None,
                 "no_prompt": False,
+                "flatten_json_fields": False,
+                "overwrite_staging_models": False,
+                "skip_model_props": False,
             },
             "properties": {
                 "templates_folder": None,
@@ -186,6 +189,14 @@ class DbtCovesFlags:
                     ] = self.args.exclude_relations.split(",")
                 if self.args.no_prompt:
                     self.generate["sources"]["no_prompt"] = True
+                if self.args.flatten_json_fields:
+                    self.generate["sources"]["flatten_json_fields"] = True
+                if self.args.overwrite_staging_models:
+                    self.generate["sources"]["overwrite_staging_models"] = True
+                if self.args.skip_model_props:
+                    self.generate["sources"]["skip_model_props"] = True
+
+            # generate properties
             if self.args.cls.__name__ == "GeneratePropertiesTask":
                 if self.args.templates_folder:
                     self.generate["properties"]["templates_folder"] = self.args.templates_folder
@@ -203,6 +214,8 @@ class DbtCovesFlags:
                     self.generate["properties"]["selector"] = self.args.selector
                 if self.args.no_prompt:
                     self.generate["properties"]["no_prompt"] = True
+
+            # generate metadata
             if self.args.cls.__name__ == "GenerateMetadataTask":
                 if self.args.database:
                     self.generate["metadata"]["database"] = self.args.database
@@ -223,12 +236,7 @@ class DbtCovesFlags:
                 if self.args.no_prompt:
                     self.generate["metadata"]["no_prompt"] = True
 
-            if self.args.cls.__name__ == "InitTask":
-                if self.args.template:
-                    self.init["template"] = self.args.template
-                if self.args.current_dir:
-                    self.init["current-dir"] = self.args.current_dir
-
+            # load airbyte
             if self.args.cls.__name__ == "LoadAirbyteTask":
                 if self.args.path:
                     self.load["airbyte"]["path"] = self.args.path
@@ -253,6 +261,7 @@ class DbtCovesFlags:
                 if self.args.secrets_key:
                     self.load["airbyte"]["secrets_key"] = self.args.secrets_key
 
+            # load fivetran
             if self.args.cls.__name__ == "LoadFivetranTask":
                 if self.args.path:
                     self.load["fivetran"]["path"] = self.args.path
@@ -279,6 +288,7 @@ class DbtCovesFlags:
                 if self.args.secrets_key:
                     self.load["fivetran"]["secrets_key"] = self.args.secrets_key
 
+            # extract airbyte
             if self.args.cls.__name__ == "ExtractAirbyteTask":
                 if self.args.path:
                     self.extract["airbyte"]["path"] = self.args.path
@@ -286,6 +296,7 @@ class DbtCovesFlags:
                     self.extract["airbyte"]["host"] = self.args.host
                     self.extract["airbyte"]["port"] = self.args.port
 
+            # extract fivetran
             if self.args.cls.__name__ == "ExtractFivetranTask":
                 if self.args.path:
                     self.extract["fivetran"]["path"] = self.args.path
@@ -299,14 +310,17 @@ class DbtCovesFlags:
                 if self.args.open_ssl_public_key:
                     self.setup["all"]["open_ssl_public_key"] = self.args.open_ssl_public_key
 
+            # setup ssh
             if self.args.cls.__name__ == "SetupSSHTask":
                 if self.args.open_ssl_public_key:
                     self.setup["ssh"]["open_ssl_public_key"] = self.args.open_ssl_public_key
 
+            # setup git
             if self.args.cls.__name__ == "SetupGitTask":
                 if self.args.no_prompt:
                     self.setup["git"]["no_prompt"] = self.args.no_prompt
 
+            # run dbt
             if self.args.cls.__name__ == "RunDbtTask":
                 if self.args.command:
                     self.dbt["command"] = self.args.command

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -89,6 +89,26 @@
               "description": "Default file to find metadata file used to fill in field descriptions",
               "type": "string",
               "minLength": 1
+            },
+            "flatten_json_fields": {
+              "title": "Flatten JSON fields",
+              "description": "Flatten JSON fields",
+              "type": "boolean"
+            },
+            "overwrite_staging_models": {
+              "title": "Overwrite staging models",
+              "description": "Overwrite existent staging files",
+              "type": "boolean"
+            },
+            "skip_model_props": {
+              "title": "Skip model props",
+              "description": "Don't create model's property (yml) files",
+              "type": "boolean"
+            },
+            "no_prompt": {
+              "title": "No prompt",
+              "description": "Silently generate source dbt models",
+              "type": "boolean"
             }
           },
           "required": [],
@@ -145,6 +165,11 @@
               "description": "dbt selector definition e.g. my_selector.yml",
               "type": "string",
               "minLength": 1
+            },
+            "no_prompt": {
+              "title": "No prompt",
+              "description": "Silently dbt models property files",
+              "type": "boolean"
             }
           },
           "required": []
@@ -195,6 +220,11 @@
               "type": "string",
               "minLength": 1,
               "pattern": ".+(.csv)$"
+            },
+            "no_prompt": {
+              "title": "No prompt",
+              "description": "Silently generate metadata",
+              "type": "boolean"
             }
           },
           "required": [],


### PR DESCRIPTION
`generate sources` new flags:
- `--flatten-json-fields`
- `--overwrite-staging-models`
- `--skip-model-props`

Removed `--no-prompt` from base generate task: it made no sense as generate can't be run without a subcommand
Removed `InitTask` from flags: it was a reference to the old `dbt-coves init`
Updated schema-config-json and readme.md