### PR TITLE
fix Fixing error where complex column types contain a list or null

### DIFF
--- a/dbt_coves/tasks/generate/sources.py
+++ b/dbt_coves/tasks/generate/sources.py
@@ -317,7 +317,8 @@ class GenerateSourcesTask(BaseGenerateTask):
             config_db = ""
         _, data = self.adapter.execute(
             f"SELECT {', '.join(json_cols)} FROM {config_db}{relation.schema}.{relation.name} \
-                WHERE {' IS NOT NULL AND '.join([' CAST(' + sub + ' AS VARCHAR) ' for sub in json_cols])} IS NOT NULL limit 1",
+                WHERE {' IS NOT NULL AND '.join([' CAST(' + sub + ' AS VARCHAR) ' for sub in json_cols])} \
+                IS NOT NULL limit 1",
             fetch=True,
         )
         result = dict()

--- a/dbt_coves/tasks/generate/sources.py
+++ b/dbt_coves/tasks/generate/sources.py
@@ -36,13 +36,13 @@ class GenerateSourcesTask(BaseGenerateTask):
             "--schemas",
             type=str,
             help="Comma separated list of schemas where raw data resides, "
-                 "i.e. 'RAW_SALESFORCE,RAW_HUBSPOT'",
+            "i.e. 'RAW_SALESFORCE,RAW_HUBSPOT'",
         )
         subparser.add_argument(
             "--select-relations",
             type=str,
             help="Comma separated list of relations where raw data resides, "
-                 "i.e. 'RAW_HUBSPOT_PRODUCTS,RAW_SALESFORCE_USERS'",
+            "i.e. 'RAW_HUBSPOT_PRODUCTS,RAW_SALESFORCE_USERS'",
         )
         subparser.add_argument(
             "--exclude-relations",
@@ -53,31 +53,31 @@ class GenerateSourcesTask(BaseGenerateTask):
             "--sources-destination",
             type=str,
             help="Where sources yml files will be generated, default: "
-                 "'models/staging/{{schema}}/sources.yml'",
+            "'models/staging/{{schema}}/sources.yml'",
         )
         subparser.add_argument(
             "--models-destination",
             type=str,
             help="Where models sql files will be generated, default: "
-                 "'models/staging/{{schema}}/{{relation}}.sql'",
+            "'models/staging/{{schema}}/{{relation}}.sql'",
         )
         subparser.add_argument(
             "--model-props-destination",
             type=str,
             help="Where models yml files will be generated, default: "
-                 "'models/staging/{{schema}}/{{relation}}.yml'",
+            "'models/staging/{{schema}}/{{relation}}.yml'",
         )
         subparser.add_argument(
             "--update-strategy",
             type=str,
             help="Action to perform when a property file already exists: "
-                 "'update', 'recreate', 'fail', 'ask' (per file)",
+            "'update', 'recreate', 'fail', 'ask' (per file)",
         )
         subparser.add_argument(
             "--templates-folder",
             type=str,
             help="Folder with jinja templates that override default "
-                 "sources generation templates, i.e. 'templates'",
+            "sources generation templates, i.e. 'templates'",
         )
         subparser.add_argument(
             "--metadata",


### PR DESCRIPTION
Current when i use the tool to generate a table from a source that needs to be flattened i get an error when the columns are either null or of a json list format, this PR goes some way to try to ensure that all variant columns queried return a non null value and when the variant in the column is not an object (eg list) then that denesting is skipped.