### PR TITLE
feat: add --dag-destination to generate airflow-dags

### DIFF
--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -55,6 +55,7 @@ class GenerateDocsModel(BaseModel):
 
 class GenerateAirflowDagsModel(BaseModel):
     from_path: Optional[str] = ""
+    dag_destination: Optional[str] = ""
     validate_operators: Optional[bool] = False
     generators_folder: Optional[str] = "dbt_coves.tasks.generate.airflow_generators"
     generators_params: Optional[Dict[str, Any]] = {}
@@ -189,6 +190,7 @@ class DbtCovesConfig:
         "generate.docs.merge_deferred",
         "generate.docs.state",
         "generate.airflow_dags.from_path",
+        "generate.airflow_dags.dag_destination",
         "generate.airflow_dags.validate_operators",
         "generate.airflow_dags.generators_folder",
         "generate.airflow_dags.generators_params",

--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -54,7 +54,7 @@ class GenerateDocsModel(BaseModel):
 
 
 class GenerateAirflowDagsModel(BaseModel):
-    from_path: Optional[str] = ""
+    yml_path: Optional[str] = ""
     target_path: Optional[str] = ""
     validate_operators: Optional[bool] = False
     generators_folder: Optional[str] = "dbt_coves.tasks.generate.airflow_generators"
@@ -189,8 +189,8 @@ class DbtCovesConfig:
         "generate.metadata.no_prompt",
         "generate.docs.merge_deferred",
         "generate.docs.state",
-        "generate.airflow_dags.from_path",
-        "generate.airflow_dags.target_path",
+        "generate.airflow_dags.yml_path",
+        "generate.airflow_dags.dag_path",
         "generate.airflow_dags.validate_operators",
         "generate.airflow_dags.generators_folder",
         "generate.airflow_dags.generators_params",

--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -55,7 +55,7 @@ class GenerateDocsModel(BaseModel):
 
 class GenerateAirflowDagsModel(BaseModel):
     from_path: Optional[str] = ""
-    dag_destination: Optional[str] = ""
+    target_path: Optional[str] = ""
     validate_operators: Optional[bool] = False
     generators_folder: Optional[str] = "dbt_coves.tasks.generate.airflow_generators"
     generators_params: Optional[Dict[str, Any]] = {}
@@ -190,7 +190,7 @@ class DbtCovesConfig:
         "generate.docs.merge_deferred",
         "generate.docs.state",
         "generate.airflow_dags.from_path",
-        "generate.airflow_dags.dag_destination",
+        "generate.airflow_dags.target_path",
         "generate.airflow_dags.validate_operators",
         "generate.airflow_dags.generators_folder",
         "generate.airflow_dags.generators_params",

--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -55,7 +55,7 @@ class GenerateDocsModel(BaseModel):
 
 class GenerateAirflowDagsModel(BaseModel):
     yml_path: Optional[str] = ""
-    target_path: Optional[str] = ""
+    dags_path: Optional[str] = ""
     validate_operators: Optional[bool] = False
     generators_folder: Optional[str] = "dbt_coves.tasks.generate.airflow_generators"
     generators_params: Optional[Dict[str, Any]] = {}
@@ -190,7 +190,7 @@ class DbtCovesConfig:
         "generate.docs.merge_deferred",
         "generate.docs.state",
         "generate.airflow_dags.yml_path",
-        "generate.airflow_dags.dag_path",
+        "generate.airflow_dags.dags_path",
         "generate.airflow_dags.validate_operators",
         "generate.airflow_dags.generators_folder",
         "generate.airflow_dags.generators_params",

--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -33,13 +33,14 @@ class GenerateAirflowDagsTask(NonDbtBaseConfiguredTask):
             help="Generate Airflow Python DAGs from YML configuration files",
         )
         subparser.add_argument(
-            "--from-path",
+            "--yml-path",
+            "--yaml-path",
             type=str,
             required=False,
             help="Folder where YML files will be read from",
         )
         subparser.add_argument(
-            "--target-path",
+            "--dag-path",
             type=str,
             required=False,
             help="Folder where generated Python files will be stored",
@@ -97,8 +98,8 @@ class GenerateAirflowDagsTask(NonDbtBaseConfiguredTask):
 
     def _generate_dag(self, yml_filepath: Path):
         yaml.FullLoader.add_constructor("tag:yaml.org,2002:timestamp", self.date_constructor)
-        if self.target_path:
-            dag_destination = self.target_path.joinpath(f"{yml_filepath.stem}.py")
+        if self.dag_path:
+            dag_destination = self.dag_path.joinpath(f"{yml_filepath.stem}.py")
         else:
             dag_destination = yml_filepath.with_suffix(".py")
         self.build_dag_file(
@@ -117,7 +118,7 @@ class GenerateAirflowDagsTask(NonDbtBaseConfiguredTask):
     @trackable
     def run(self):
         self.generation_results = set()
-        self.ymls_path = Path(self.get_config_value("from_path"))
+        self.ymls_path = Path(self.get_config_value("yml_path"))
         self.validate_operators = self.get_config_value("validate_operators")
         self.secrets_path = self.get_config_value("secrets_path")
         self.secrets_manager = self.get_config_value("secrets_manager")
@@ -126,10 +127,10 @@ class GenerateAirflowDagsTask(NonDbtBaseConfiguredTask):
             raise GenerateAirflowDagsException(
                 "Can't use 'secrets_path' and 'secrets_manager' simultaneously."
             )
-        self.target_path = self.get_config_value("target_path")
-        if self.target_path:
-            self.target_path = Path(self.target_path).resolve()
-            self.target_path.mkdir(exist_ok=True, parents=True)
+        self.dag_path = self.get_config_value("dag_path")
+        if self.dag_path:
+            self.dag_path = Path(self.dag_path).resolve()
+            self.dag_path.mkdir(exist_ok=True, parents=True)
         if self.ymls_path.is_dir():
             for yml_filepath in glob(f"{self.ymls_path}/*.yml"):
                 self._generate_dag(Path(yml_filepath))

--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -39,7 +39,7 @@ class GenerateAirflowDagsTask(NonDbtBaseConfiguredTask):
             help="Folder where YML files will be read from",
         )
         subparser.add_argument(
-            "--dag-destination",
+            "--target-path",
             type=str,
             required=False,
             help="Folder where generated Python files will be stored",
@@ -97,8 +97,8 @@ class GenerateAirflowDagsTask(NonDbtBaseConfiguredTask):
 
     def _generate_dag(self, yml_filepath: Path):
         yaml.FullLoader.add_constructor("tag:yaml.org,2002:timestamp", self.date_constructor)
-        if self.destination_path:
-            dag_destination = self.destination_path.joinpath(f"{yml_filepath.stem}.py")
+        if self.target_path:
+            dag_destination = self.target_path.joinpath(f"{yml_filepath.stem}.py")
         else:
             dag_destination = yml_filepath.with_suffix(".py")
         self.build_dag_file(
@@ -126,10 +126,10 @@ class GenerateAirflowDagsTask(NonDbtBaseConfiguredTask):
             raise GenerateAirflowDagsException(
                 "Can't use 'secrets_path' and 'secrets_manager' simultaneously."
             )
-        self.destination_path = self.get_config_value("dag_destination")
-        if self.destination_path:
-            self.destination_path = Path(self.destination_path).resolve()
-            self.destination_path.mkdir(exist_ok=True, parents=True)
+        self.target_path = self.get_config_value("target_path")
+        if self.target_path:
+            self.target_path = Path(self.target_path).resolve()
+            self.target_path.mkdir(exist_ok=True, parents=True)
         if self.ymls_path.is_dir():
             for yml_filepath in glob(f"{self.ymls_path}/*.yml"):
                 self._generate_dag(Path(yml_filepath))

--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -40,7 +40,7 @@ class GenerateAirflowDagsTask(NonDbtBaseConfiguredTask):
             help="Folder where YML files will be read from",
         )
         subparser.add_argument(
-            "--dag-path",
+            "--dags-path",
             type=str,
             required=False,
             help="Folder where generated Python files will be stored",
@@ -98,8 +98,8 @@ class GenerateAirflowDagsTask(NonDbtBaseConfiguredTask):
 
     def _generate_dag(self, yml_filepath: Path):
         yaml.FullLoader.add_constructor("tag:yaml.org,2002:timestamp", self.date_constructor)
-        if self.dag_path:
-            dag_destination = self.dag_path.joinpath(f"{yml_filepath.stem}.py")
+        if self.dags_path:
+            dag_destination = self.dags_path.joinpath(f"{yml_filepath.stem}.py")
         else:
             dag_destination = yml_filepath.with_suffix(".py")
         self.build_dag_file(
@@ -127,10 +127,10 @@ class GenerateAirflowDagsTask(NonDbtBaseConfiguredTask):
             raise GenerateAirflowDagsException(
                 "Can't use 'secrets_path' and 'secrets_manager' simultaneously."
             )
-        self.dag_path = self.get_config_value("dag_path")
-        if self.dag_path:
-            self.dag_path = Path(self.dag_path).resolve()
-            self.dag_path.mkdir(exist_ok=True, parents=True)
+        self.dags_path = self.get_config_value("dags_path")
+        if self.dags_path:
+            self.dags_path = Path(self.dags_path).resolve()
+            self.dags_path.mkdir(exist_ok=True, parents=True)
         if self.ymls_path.is_dir():
             for yml_filepath in glob(f"{self.ymls_path}/*.yml"):
                 self._generate_dag(Path(yml_filepath))

--- a/dbt_coves/tasks/generate/airflow_generators/base.py
+++ b/dbt_coves/tasks/generate/airflow_generators/base.py
@@ -157,7 +157,6 @@ class BaseDbtCovesTaskGenerator:
         Receive task_id, connection_id and Operator-string
         Returns Airflow call as a string
         """
-
         func_call = ", ".join(
             f'{k}="{v}"' if isinstance(v, str) else f"{k}={v}" for k, v in kwargs.items()
         )

--- a/dbt_coves/tasks/generate/properties.py
+++ b/dbt_coves/tasks/generate/properties.py
@@ -155,10 +155,7 @@ class GeneratePropertiesTask(BaseGenerateTask):
             return selected_properties
 
     def select_models(self, dbt_models):
-        dbt_models_manifest_naming = [
-            f"{model['resource_type']}.{model['package_name']}.{model['name']}"
-            for model in dbt_models
-        ]
+        dbt_models_manifest_naming = [m["unique_id"] for m in dbt_models]
 
         # Filter user selection
         if len(dbt_models_manifest_naming) == 1:

--- a/dbt_coves/utils/flags.py
+++ b/dbt_coves/utils/flags.py
@@ -74,7 +74,7 @@ class DbtCovesFlags:
             },
             "airflow_dags": {
                 "from_path": None,
-                "dag_destination": None,
+                "target_path": None,
                 "validate_operators": False,
                 "generators_folder": None,
                 "generators_params": None,
@@ -266,8 +266,8 @@ class DbtCovesFlags:
             if self.args.cls.__name__ == "GenerateAirflowDagsTask":
                 if self.args.from_path:
                     self.generate["airflow_dags"]["from_path"] = self.args.from_path
-                if self.args.dag_destination:
-                    self.generate["airflow_dags"]["dag_destination"] = self.args.dag_destination
+                if self.args.target_path:
+                    self.generate["airflow_dags"]["target_path"] = self.args.target_path
                 if self.args.validate_operators:
                     self.generate["airflow_dags"][
                         "validate_operators"

--- a/dbt_coves/utils/flags.py
+++ b/dbt_coves/utils/flags.py
@@ -74,7 +74,7 @@ class DbtCovesFlags:
             },
             "airflow_dags": {
                 "yml_path": None,
-                "dag_path": None,
+                "dags_path": None,
                 "validate_operators": False,
                 "generators_folder": None,
                 "generators_params": None,
@@ -266,8 +266,8 @@ class DbtCovesFlags:
             if self.args.cls.__name__ == "GenerateAirflowDagsTask":
                 if self.args.yml_path:
                     self.generate["airflow_dags"]["yml_path"] = self.args.yml_path
-                if self.args.dag_path:
-                    self.generate["airflow_dags"]["dag_path"] = self.args.dag_path
+                if self.args.dags_path:
+                    self.generate["airflow_dags"]["dags_path"] = self.args.dags_path
                 if self.args.validate_operators:
                     self.generate["airflow_dags"][
                         "validate_operators"

--- a/dbt_coves/utils/flags.py
+++ b/dbt_coves/utils/flags.py
@@ -74,6 +74,7 @@ class DbtCovesFlags:
             },
             "airflow_dags": {
                 "from_path": None,
+                "dag_destination": None,
                 "validate_operators": False,
                 "generators_folder": None,
                 "generators_params": None,
@@ -265,6 +266,8 @@ class DbtCovesFlags:
             if self.args.cls.__name__ == "GenerateAirflowDagsTask":
                 if self.args.from_path:
                     self.generate["airflow_dags"]["from_path"] = self.args.from_path
+                if self.args.dag_destination:
+                    self.generate["airflow_dags"]["dag_destination"] = self.args.dag_destination
                 if self.args.validate_operators:
                     self.generate["airflow_dags"][
                         "validate_operators"

--- a/dbt_coves/utils/flags.py
+++ b/dbt_coves/utils/flags.py
@@ -73,8 +73,8 @@ class DbtCovesFlags:
                 "state": None,
             },
             "airflow_dags": {
-                "from_path": None,
-                "target_path": None,
+                "yml_path": None,
+                "dag_path": None,
                 "validate_operators": False,
                 "generators_folder": None,
                 "generators_params": None,
@@ -264,10 +264,10 @@ class DbtCovesFlags:
 
             # generate airflow_dags
             if self.args.cls.__name__ == "GenerateAirflowDagsTask":
-                if self.args.from_path:
-                    self.generate["airflow_dags"]["from_path"] = self.args.from_path
-                if self.args.target_path:
-                    self.generate["airflow_dags"]["target_path"] = self.args.target_path
+                if self.args.yml_path:
+                    self.generate["airflow_dags"]["yml_path"] = self.args.yml_path
+                if self.args.dag_path:
+                    self.generate["airflow_dags"]["dag_path"] = self.args.dag_path
                 if self.args.validate_operators:
                     self.generate["airflow_dags"][
                         "validate_operators"


### PR DESCRIPTION
This PR introduces a new `--dag-destination` argument for `generate airflow-dags`

If passed, dbt-coves will store `.py` generated files there (creating the folder if needed)
If not passed, the previous behavior is mantained: Python file(s) is a sibling of the YML input file(s)