### PR TITLE
DCV-2136 dbt command OOMKilled silently + no feedback given

### DIFF
--- a/dbt_coves/core/main.py
+++ b/dbt_coves/core/main.py
@@ -2,6 +2,7 @@ import argparse
 import pathlib
 import sys
 import uuid
+from subprocess import CalledProcessError
 from typing import List
 
 import pyfiglet
@@ -251,6 +252,17 @@ def main(parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = li
             "No [u]dbt_project.yml[/u] found. Current folder doesn't look like a dbt project."
         )
         return 1
+    except CalledProcessError as cpe:
+        import traceback
+
+        logger.debug(traceback.format_exc())
+        if cpe.returncode == 137:
+            console.print(
+                "[red]The process was killed by the OS due to running out of memory.[/red]"
+            )
+        console.print(f"[red]:cross_mark:[/red] {cpe.stderr}")
+
+        return cpe.returncode
     except Exception as ex:
         import traceback
 

--- a/dbt_coves/tasks/dbt/main.py
+++ b/dbt_coves/tasks/dbt/main.py
@@ -132,16 +132,15 @@ class RunDbtTask(NonDbtBaseConfiguredTask):
             cmd_list = shlex.split(command)
 
         try:
-            output = subprocess.check_output(cmd_list, env=env, cwd=cwd)
+            output = subprocess.check_output(cmd_list, env=env, cwd=cwd, stderr=subprocess.PIPE)
             console.print(
                 f"{Text.from_ansi(output.decode())}\n"
                 f"[green]{command} :heavy_check_mark:[/green]"
             )
         except subprocess.CalledProcessError as e:
-            raise RunDbtException(
-                f"Exception ocurred running [red]{command}[/red]:\n"
-                f"{Text.from_ansi(e.output.decode())}"
-            )
+            formatted = f"{Text.from_ansi(e.stderr.decode())}"
+            e.stderr = f"Exception ocurred running [red]{command}[/red]:\n {formatted}"
+            raise
 
     def get_config_value(self, key):
         return self.coves_config.integrated["dbt"][key]


### PR DESCRIPTION
As we've been using `subprocess` in many stages in dbt-coves, I think the most elegant solution to support multiple (and unexpected) return codes is to support subprocess' `CalledProcessError` in dbt.coves `main` runner (apart from MissingCommand, MissingDbt, and generic Exception).

Each command that is Subprocess-based is responsible of raising the Exception instead of running custom command-exceptions (like DbtRunException)

In [this case ](https://github.com/datacoves/dbt-coves/commit/ebe3767419c7cfbfe17d7fcccf485b5952910dc4#diff-d8dfc6dfacceeacf72c5588fe5efc1c7717196bfce3ddfd717c23243f19118e6R142), when `dbt-coves dbt` finds a Subprocess Exception, it customizes it's stderr and is raised back to dbt-coves: then `main` [exits whatever code resulted](https://github.com/datacoves/dbt-coves/commit/ebe3767419c7cfbfe17d7fcccf485b5952910dc4#diff-f12a1e7740a7138d5d7a8348ec01f27d47138299925164b7331bdeeb939c0a02R265) (warning severely if it's OOM)