### PR TITLE
fix: Fixes to Config's env_var usage

### DIFF
--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -280,7 +280,7 @@ class DbtCovesConfig:
             self._config = ConfigModel(**yaml_dict)
 
     def replace_env_vars(self, yaml_dict: Dict) -> Dict:
-        # Define a regular expression pattern to find placeholders
+        # regex -> {{ env_var('ENV_VAR_NAME', 'DEFAULT_VALUE') }}
         env_var_pattern = re.compile(
             r"\{\{\s*env_var\s*\(\s*['\"]?\s*([^'\"]+)['\"]?\s*(?:,\s*['\"]?\s*([^'\"]+)['\"]?\s*)?\)\s*\}\}"
         )


### PR DESCRIPTION
Changes to "{{ env_var('variable' }}" usage in config file

Now the expression supports receiving a second group, in the form of a default value to be used in case the VAR isn't found. i.e. `"{{ env_var('SNOWFLAKE_DATABASE', 'dbt-coves') }}"`.

If no default is used, and the variable isn't found, we no longer break, instead use `""` as configuration value.