### PR TITLE
feat:DBT_PROFILES_DIR env_var takes precedence over dbt's default profilesdir

### DIFF
--- a/dbt_coves/core/main.py
+++ b/dbt_coves/core/main.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import pathlib
 import sys
 import uuid
@@ -31,7 +32,7 @@ try:
 except ImportError:
     from dbt.cli.resolvers import default_profiles_dir
 
-    PROFILES_DIR = default_profiles_dir()
+    PROFILES_DIR = os.environ.get("DBT_PROFILES_DIR") or default_profiles_dir()
     VARS_DEFAULT_IS_STR = True
 
 console = Console()


### PR DESCRIPTION
dbt-core's `default_profiles_dir` doesn't pay attention to the possible `DBT_PROFILES_DIR`

```python
def default_profiles_dir() -> Path:
    return Path.cwd() if (Path.cwd() / "profiles.yml").exists() else Path.home() / ".dbt"
```

Now, if the user has set `DBT_PROFILES_DIR`, it'll take precedence over `~/.dbt`