### PR TITLE
Fix: support config.yAml file, typo on Generator error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,20 @@ generate:
   docs:
     merge_deferred: true
     state: logs/
+    dbt_args: "--no-compile --select foo --exclude bar"
+
+  airflow_dags:
+    yml_path:
+    dags_path:
+    generators_params:
+      AirbyteDbtGenerator:
+        host: "{{ env_var('AIRBYTE_HOST_NAME') }}"
+        port: "{{ env_var('AIRBYTE_PORT') }}"
+        airbyte_conn_id: airbyte_connection
+
+        dbt_project_path: "{{ env_var('DBT_HOME') }}"
+        run_dbt_compile: true
+        run_dbt_deps: false
 
 extract:
   airbyte:
@@ -671,15 +685,15 @@ load:
 
 ## env_var
 
-From `dbt-coves 1.6.28` onwards, you can consume environment variables in you config file using `{{env_var(VAR_NAME)}}`. For example:
+From `dbt-coves 1.6.28` onwards, you can consume environment variables in you config file using `"{{env_var('VAR_NAME', 'DEFAULT VALUE')}}"`. For example:
 
 ```yaml
 generate:
   sources:
-    database: "{{env_var(MAIN_DATABASE)}}"
+    database: "{{env_var('MAIN_DATABASE', 'dev_database')}}"
     schemas:
-      - "{{env_var(DEV_SCHEMA)}}"
-      - "{{env_var(STAGING_SCHEMA)}}"
+      - "{{env_var('DEV_SCHEMA', 'John')}}"
+      - "{{env_var('STAGING_SCHEMA', 'Staging')}}"
 ```
 
 ## Telemetry

--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -328,15 +328,6 @@ class DbtCovesConfig:
                     logger.debug(f"{coves_config_dir} exists and was retrieved.")
                     self._config_path = coves_config_dir
                     break
-        if self._config_path == Path(str()):
-            # If config_path wasn't overwritten it means config.yml doesn't exist
-            from rich.console import Console
-
-            console = Console()
-            console.print(
-                "No [yellow].dbt_coves/config.yml[/yellow] found, "
-                "visit https://github.com/datacoves/dbt-coves?#settings for details"
-            )
 
     def load_config(self) -> None:
         is_project_valid = self.validate_dbt_project()

--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -328,6 +328,15 @@ class DbtCovesConfig:
                     logger.debug(f"{coves_config_dir} exists and was retrieved.")
                     self._config_path = coves_config_dir
                     break
+        if self._config_path == Path(str()):
+            # If config_path wasn't overwritten it means config.yml doesn't exist
+            from rich.console import Console
+
+            console = Console()
+            console.print(
+                "No [yellow].dbt_coves/config.yml[/yellow] found, "
+                "visit https://github.com/datacoves/dbt-coves?#settings for details"
+            )
 
     def load_config(self) -> None:
         is_project_valid = self.validate_dbt_project()

--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -160,7 +160,8 @@ class ConfigModel(BaseModel):
 class DbtCovesConfig:
     """dbt-coves configuration class."""
 
-    DBT_COVES_CONFIG_FILEPATH = ".dbt_coves/config.yml"
+    DBT_COVES_CONFIG_FOLDER = ".dbt_coves"
+    DBT_COVES_CONFIG_FILEPATHS = [".dbt_coves/config.yml", ".dbt_coves/config.yaml"]
     CLI_OVERRIDE_FLAGS = [
         "generate.properties.templates_folder",
         "generate.properties.metadata",
@@ -320,13 +321,13 @@ class DbtCovesConfig:
         if self._config_path == Path(str()):
             logger.debug("Trying to find .dbt_coves in current folder")
 
-            config_path = Path(os.environ.get("DATACOVES__DBT_HOME", "")).joinpath(
-                self.DBT_COVES_CONFIG_FILEPATH
-            )
-            if config_path.exists():
-                coves_config_dir = config_path
-                logger.debug(f"{coves_config_dir} exists and was retreived.")
-                self._config_path = coves_config_dir
+            for filename in self.DBT_COVES_CONFIG_FILEPATHS:
+                config_path = Path(os.environ.get("DATACOVES__DBT_HOME", "")).joinpath(filename)
+                if config_path.exists():
+                    coves_config_dir = config_path
+                    logger.debug(f"{coves_config_dir} exists and was retrieved.")
+                    self._config_path = coves_config_dir
+                    break
 
     def load_config(self) -> None:
         is_project_valid = self.validate_dbt_project()

--- a/dbt_coves/core/exceptions.py
+++ b/dbt_coves/core/exceptions.py
@@ -2,6 +2,8 @@
 Global dbt-coves exception and warning classes.
 """
 
+import pathlib
+
 
 class DbtCovesException(Exception):
     """General Exception"""
@@ -26,3 +28,19 @@ class MissingCommand(DbtCovesException):
 
     def print_help(self):
         self.arg_parser.print_help()
+
+
+class MissingArgumentException(DbtCovesException):
+    """Thrown when an argument is missing."""
+
+    # Receives a list of arguments and the config of the task
+    def __init__(self, args, config=None):
+        self.config = config
+        message = f"Task requires the following arguments: [red]{' '.join(args)}[/red]"
+        if config and config._config_path == pathlib.Path(str()):
+            # If config_path wasn't overwritten it means config.yml doesn't exist
+            message += (
+                "\nNo [yellow].dbt_coves/config.yml[/yellow] found, "
+                "visit https://github.com/datacoves/dbt-coves?#settings for details"
+            )
+        super().__init__(message)

--- a/dbt_coves/tasks/extract/airbyte.py
+++ b/dbt_coves/tasks/extract/airbyte.py
@@ -6,6 +6,7 @@ from copy import copy
 
 from rich.console import Console
 
+from dbt_coves.core.exceptions import MissingArgumentException
 from dbt_coves.utils.api_caller import AirbyteApiCaller
 from dbt_coves.utils.tracking import trackable
 
@@ -66,10 +67,7 @@ class ExtractAirbyteTask(BaseExtractTask):
         airbyte_port = self.get_config_value("port")
 
         if not extract_destination or not airbyte_host or not airbyte_port:
-            raise AirbyteExtractorException(
-                "Couldn't start extraction: one (or more) of the following arguments is missing"
-                "either in the configuration file or Command-Line arguments: 'path', 'host', 'port'"
-            )
+            raise MissingArgumentException(["path", "host", "port"], self.coves_config)
 
         extract_destination = pathlib.Path(extract_destination)
 

--- a/dbt_coves/tasks/extract/fivetran.py
+++ b/dbt_coves/tasks/extract/fivetran.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import questionary
 from rich.console import Console
 
+from dbt_coves.core.exceptions import MissingArgumentException
 from dbt_coves.utils.api_caller import FivetranApiCaller
 from dbt_coves.utils.tracking import trackable
 from dbt_coves.utils.yaml import open_yaml
@@ -69,9 +70,8 @@ class ExtractFivetranTask(BaseExtractTask):
         if not extract_destination or not (
             (self.api_key and self.api_secret) or api_credentials_path
         ):
-            raise FivetranExtractorException(
-                "Couldn't start extraction: one (or more) of the following arguments is missing: "
-                "'path', 'api-key', 'api-secret', 'credentials'"
+            raise MissingArgumentException(
+                ["path", "api-key", "api-secret", "credentials"], self.coves_config
             )
 
         if api_credentials_path:

--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -10,6 +10,7 @@ import yaml
 from black import FileMode, format_str
 from rich.console import Console
 
+from dbt_coves.core.exceptions import MissingArgumentException
 from dbt_coves.tasks.base import NonDbtBaseTask
 from dbt_coves.utils.secrets import load_secret_manager_data
 from dbt_coves.utils.tracking import trackable
@@ -52,13 +53,11 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
             "--yml-path",
             "--yaml-path",
             type=str,
-            required=False,
             help="Folder where YML files will be read from",
         )
         subparser.add_argument(
             "--dags-path",
             type=str,
-            required=False,
             help="Folder where generated Python files will be stored",
         )
         subparser.add_argument(
@@ -133,9 +132,7 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         ymls_path = self.get_config_value("yml_path")
         dags_path = self.get_config_value("dags_path")
         if not (ymls_path and dags_path):
-            raise GenerateAirflowDagsException(
-                "You must provide source ([i]--yml-path[/i]) and destination ([i]--dags-path[/i]) of DAGs"
-            )
+            raise MissingArgumentException(["--yml-path", "--dags-path"], self.coves_config)
         self.validate_operators = self.get_config_value("validate_operators")
         self.secrets_path = self.get_config_value("secrets_path")
         self.secrets_manager = self.get_config_value("secrets_manager")

--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -24,6 +24,7 @@ AIRFLOW_K8S_CONFIG_TEMPLATE = textwrap.dedent(
             spec=k8s.V1PodSpec(
                 containers=[
                     k8s.V1Container(
+                        name='base',
                         {config}
                     )
                 ]
@@ -355,10 +356,10 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         """
         Generate the multiline config section of Airflow's K8S_INNER_CONF template
         """
+        config_lines = ""
         k8s_resources_string_template = (
             "resources=k8s.V1ResourceRequirements(requests={resources}),\n"
         )
-        config_lines = f"name='{task_name}',\n "
         for key, value in config.items():
             if key == "resources":
                 config_lines += k8s_resources_string_template.format(resources=value)

--- a/dbt_coves/tasks/generate/airflow_generators/base.py
+++ b/dbt_coves/tasks/generate/airflow_generators/base.py
@@ -114,7 +114,7 @@ class BaseDbtGenerator:
                 error_message += f"{e.stdout.decode()}\n"
             if e.stderr:
                 error_message += f"{e.stderr.decode()}"
-            raise GeneratorException(f"Exception ocurred running {command}\n{error_message}")
+            raise GeneratorException(f"Exception occurred running {command}\n{error_message}")
 
         sources_list = []
         if "No nodes selected" not in stdout:

--- a/dbt_coves/tasks/generate/templates.py
+++ b/dbt_coves/tasks/generate/templates.py
@@ -47,9 +47,7 @@ class GenerateTemplatesTask(BaseConfiguredTask):
 
         dbt_project_path = self.config.project_root
         templates_destination_path = (
-            dbt_project_path
-            / Path(self.coves_config.DBT_COVES_CONFIG_FILEPATH).parent
-            / "templates"
+            dbt_project_path / Path(self.coves_config.DBT_COVES_CONFIG_FOLDER) / "templates"
         )
         templates_destination_path.mkdir(parents=True, exist_ok=True)
 

--- a/tests/generate_docs_cases/dbt_project.yml
+++ b/tests/generate_docs_cases/dbt_project.yml
@@ -1,0 +1,19 @@
+name: test_dbt_coves_snowflake
+version: "1.0.0"
+config-version: 2
+profile: test_dbt_coves_snowflake
+model-paths: ["models"]
+analysis-paths: ["analyses"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"
+clean-targets:
+  - "target"
+  - "dbt_packages"
+models:
+  test_dbt_coves:
+    example:
+      +materialized: view


### PR DESCRIPTION
This PR:
- missing README content
- support `config.yAml` apart from `yml`
- adds `MissingArgumentException` for raising lack of mandatory arguments
  - if the runtime config doesn't have a config yml, the user is prompted he doesn't have the config file.
- fix airflow custom K8s execution PodSpec, from custom naming to `name='base'`
- fix generate docs tests (dbt_project yml was ignored)