### PR TITLE
DCV-2432 change custom_callbacks to notifications using Airflow Notifiers

### DIFF
--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -184,13 +184,24 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
             split_callback = notifier.split(".")
             module = ".".join(split_callback[:-1])
             callback_class = split_callback[-1]
-            callback_args = definition.get("args", {})
+            callback_args = definition.get("args")
             self.dag_output["imports"].append(f"from {module} import {callback_class}\n")
             usage_args = []
-            for arg, value in callback_args.items():
-                if isinstance(value, str):
-                    value = f'"{value}"'
-                usage_args.append(f"{arg}={value}")
+            if isinstance(callback_args, dict):
+                for arg, value in callback_args.items():
+                    if isinstance(value, str):
+                        value = f'"{value}"'
+                    usage_args.append(f"{arg}={value}")
+            if isinstance(callback_args, list):
+                breakpoint()
+                for arg in callback_args:
+                    if isinstance(arg, dict):
+                        arg = self.dag_args_to_string(arg, indent=4)
+                        usage_args.append(arg)
+                    if isinstance(arg, int):
+                        usage_args.append(f"{arg}")
+                    if isinstance(arg, str):
+                        usage_args.append(f'"{arg}"')
             callback_usage = f"{callback_class}({','.join(usage_args)})"
             callback_output.append(f"{2 * ' '}{callback}={callback_usage}")
         return callback_output

--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -176,7 +176,10 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         for callback, definition in notifiers.items():
             notifier = definition["notifier"]
             # Splitting into module and class
-            module, _, notifier_class = notifier.rsplit(".", 2)
+            # e.g. 'dbt_coves.notifications.slack.SlackNotifier'
+            split_notifier = notifier.split(".")
+            module = ".".join(split_notifier[:-1])
+            notifier_class = split_notifier[-1]
             args = definition.get("args", {})
             self.dag_output["imports"].append(f"from {module} import {notifier_class}\n")
             notifier_args = ", ".join([f"{key}='{value}'" for key, value in args.items()])

--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -193,7 +193,6 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
                         value = f'"{value}"'
                     usage_args.append(f"{arg}={value}")
             if isinstance(callback_args, list):
-                breakpoint()
                 for arg in callback_args:
                     if isinstance(arg, dict):
                         arg = self.dag_args_to_string(arg, indent=4)

--- a/tests/generate_dags_cases/input/basic_dag.yml
+++ b/tests/generate_dags_cases/input/basic_dag.yml
@@ -7,13 +7,13 @@ default_args:
 catchup: false
 notifications:
   on_success_callback:
-    notifier: notifiers.datacoves.ms_teams.MSTeamsNotifier
+    callback: time.sleep
     args:
-      connection_id: DATACOVES_MS_TEAMS
+      - 1
   on_failure_callback:
     callback: time.sleep
     args:
-      connection_id: DATACOVES_MS_TEAMS
+      - 1
 nodes:
   transform:
     type: task

--- a/tests/generate_dags_cases/input/basic_dag.yml
+++ b/tests/generate_dags_cases/input/basic_dag.yml
@@ -7,13 +7,13 @@ default_args:
 catchup: false
 notifications:
   on_success_callback:
-    notifier: time.sleep
+    notifier: notifiers.dbt_coves.test
     args:
-      secs: 1
+      message: Success
   on_failure_callback:
-    notifier: time.sleep
+    notifier: notifiers.dbt_coves.test
     args:
-      secs: 1
+      message: Fail
 nodes:
   transform:
     type: task

--- a/tests/generate_dags_cases/input/basic_dag.yml
+++ b/tests/generate_dags_cases/input/basic_dag.yml
@@ -5,15 +5,15 @@ tags:
 default_args:
   start_date: 2023-01-01
 catchup: false
-notifications:
+callbacks:
   on_success_callback:
-    notifier: time.sleep
+    callback: time.sleep
     args:
-      seconds: 1
+      - 1
   on_failure_callback:
-    notifier: time.sleep
+    callback: time.sleep
     args:
-      seconds: 1
+      - 1
 nodes:
   transform:
     type: task

--- a/tests/generate_dags_cases/input/basic_dag.yml
+++ b/tests/generate_dags_cases/input/basic_dag.yml
@@ -7,13 +7,13 @@ default_args:
 catchup: false
 notifications:
   on_success_callback:
-    notifier: notifiers.dbt_coves.test
+    notifier: time.sleep
     args:
-      message: Success
+      seconds: 1
   on_failure_callback:
-    notifier: notifiers.dbt_coves.test
+    notifier: time.sleep
     args:
-      message: Fail
+      seconds: 1
 nodes:
   transform:
     type: task

--- a/tests/generate_dags_cases/input/basic_dag.yml
+++ b/tests/generate_dags_cases/input/basic_dag.yml
@@ -5,15 +5,13 @@ tags:
 default_args:
   start_date: 2023-01-01
 catchup: false
-custom_callbacks:
+notifications:
   on_success_callback:
-    module: time
-    callable: sleep
+    notifier: time.sleep
     args:
       secs: 1
   on_failure_callback:
-    module: time
-    callable: sleep
+    notifier: time.sleep
     args:
       secs: 1
 nodes:

--- a/tests/generate_dags_cases/input/basic_dag.yml
+++ b/tests/generate_dags_cases/input/basic_dag.yml
@@ -5,15 +5,15 @@ tags:
 default_args:
   start_date: 2023-01-01
 catchup: false
-callbacks:
+notifications:
   on_success_callback:
-    callback: time.sleep
+    notifier: notifiers.datacoves.ms_teams.MSTeamsNotifier
     args:
-      - 1
+      connection_id: DATACOVES_MS_TEAMS
   on_failure_callback:
     callback: time.sleep
     args:
-      - 1
+      connection_id: DATACOVES_MS_TEAMS
 nodes:
   transform:
     type: task


### PR DESCRIPTION
This PR changes the `custom_callbacks` YML-dag structure for a `notifiers` one based on newer [Airflow Notifiers](https://airflow.apache.org/docs/apache-airflow/2.6.0/howto/notifications.html#using-a-notifier)

