### PR TITLE
DCV-2575 changes to dlt data-sync

### DIFF
--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -149,12 +149,26 @@ class RunDbtModel(BaseModel):
     cleanup: Optional[bool] = False
 
 
+class RedshiftDataSyncModel(BaseModel):
+    tables: Optional[List[str]] = []
+
+
+class SnowflakeDataSyncModel(BaseModel):
+    tables: Optional[List[str]] = []
+
+
+class DataSyncModel(BaseModel):
+    redshift: Optional[RedshiftDataSyncModel] = RedshiftDataSyncModel()
+    snowflake: Optional[SnowflakeDataSyncModel] = SnowflakeDataSyncModel()
+
+
 class ConfigModel(BaseModel):
     generate: Optional[GenerateModel] = GenerateModel()
     extract: Optional[ExtractModel] = ExtractModel()
     load: Optional[LoadModel] = LoadModel()
     setup: Optional[SetupModel] = SetupModel()
     dbt: Optional[RunDbtModel] = RunDbtModel()
+    data_sync: Optional[DataSyncModel] = DataSyncModel()
 
 
 class DbtCovesConfig:
@@ -240,6 +254,8 @@ class DbtCovesConfig:
         "load.fivetran.secrets_project",
         "load.fivetran.secrets_tags",
         "load.fivetran.secrets_key",
+        "data_sync.redshift.tables",
+        "data_sync.snowflake.tables",
     ]
 
     def __init__(self, flags: DbtCovesFlags) -> None:

--- a/dbt_coves/tasks/data_sync/base.py
+++ b/dbt_coves/tasks/data_sync/base.py
@@ -1,0 +1,38 @@
+"""
+Bring all common (shared across Snowflake and Redshift) dlt functionalities here
+"""
+
+import os
+
+import dlt
+from dlt.sources.credentials import ConnectionStringCredentials
+
+from dbt_coves.tasks.base import BaseTask
+
+from .sql_database import sql_database
+
+
+class BaseDataSyncTask(BaseTask):
+    def get_source_connection_string(self):
+        self.source_connection_string = os.environ.get("DATA_SYNC_SOURCE_CONNECTION_STRING")
+        assert self.source_connection_string, (
+            "Environment variable " "DATA_SYNC_SOURCE_CONNECTION_STRING is not defined"
+        )
+
+    def load_entire_database(self) -> None:
+        """Use the sql_database source to completely load all tables in a database"""
+        pipeline = dlt.pipeline(
+            progress="enlighten",
+            pipeline_name="source",
+            destination=self.destination,
+            dataset_name=self.args.source,
+        )
+
+        # By default the sql_database source reflects all tables in the schema
+        # The database credentials are sourced from the `.dlt/secrets.toml` configuration
+        credentials = ConnectionStringCredentials(self.source_connection_string)
+        source = sql_database(credentials=credentials)
+
+        # Run the pipeline. For a large db this may take a while
+        info = pipeline.run(source, write_disposition="replace")
+        print(info)

--- a/dbt_coves/tasks/data_sync/base.py
+++ b/dbt_coves/tasks/data_sync/base.py
@@ -6,20 +6,23 @@ import os
 
 import dlt
 from dlt.sources.credentials import ConnectionStringCredentials
+from rich.console import Console
 
-from dbt_coves.tasks.base import BaseTask
+from dbt_coves.tasks.base import NonDbtBaseConfiguredTask
 
 from .sql_database import sql_database
 
+console = Console()
 
-class BaseDataSyncTask(BaseTask):
+
+class BaseDataSyncTask(NonDbtBaseConfiguredTask):
     def get_source_connection_string(self):
         self.source_connection_string = os.environ.get("DATA_SYNC_SOURCE_CONNECTION_STRING")
         assert self.source_connection_string, (
             "Environment variable " "DATA_SYNC_SOURCE_CONNECTION_STRING is not defined"
         )
 
-    def load_entire_database(self) -> None:
+    def perform_sync(self) -> None:
         """Use the sql_database source to completely load all tables in a database"""
         pipeline = dlt.pipeline(
             progress="enlighten",
@@ -31,8 +34,9 @@ class BaseDataSyncTask(BaseTask):
         # By default the sql_database source reflects all tables in the schema
         # The database credentials are sourced from the `.dlt/secrets.toml` configuration
         credentials = ConnectionStringCredentials(self.source_connection_string)
-        source = sql_database(credentials=credentials)
+        source = sql_database(credentials=credentials, table_names=self.tables or None)
 
         # Run the pipeline. For a large db this may take a while
+        console.print(f"Dumping database to {self.destination}")
         info = pipeline.run(source, write_disposition="replace")
         print(info)

--- a/dbt_coves/tasks/data_sync/main.py
+++ b/dbt_coves/tasks/data_sync/main.py
@@ -2,8 +2,8 @@ from rich.console import Console
 
 from dbt_coves.tasks.base import BaseTask
 
-from .redshift import RedshiftDestinationDataSyncTask
-from .snowflake import SnowflakeDestinationDataSyncTask
+from .redshift import RedshiftDataSyncTask
+from .snowflake import SnowflakeDataSyncTask
 
 console = Console()
 
@@ -24,7 +24,7 @@ class DataSyncTask(BaseTask):
         )
         subparser.set_defaults(cls=cls, which="data_sync")
         sub_parsers = subparser.add_subparsers(title="dbt-coves data-sync commands", dest="task")
-        SnowflakeDestinationDataSyncTask.register_parser(sub_parsers, base_subparser)
-        RedshiftDestinationDataSyncTask.register_parser(sub_parsers, base_subparser)
+        SnowflakeDataSyncTask.register_parser(sub_parsers, base_subparser)
+        RedshiftDataSyncTask.register_parser(sub_parsers, base_subparser)
         cls.arg_parser = subparser
         return subparser

--- a/dbt_coves/tasks/data_sync/main.py
+++ b/dbt_coves/tasks/data_sync/main.py
@@ -2,6 +2,7 @@ from rich.console import Console
 
 from dbt_coves.tasks.base import BaseTask
 
+from .redshift import RedshiftDestinationDataSyncTask
 from .snowflake import SnowflakeDestinationDataSyncTask
 
 console = Console()
@@ -24,5 +25,6 @@ class DataSyncTask(BaseTask):
         subparser.set_defaults(cls=cls, which="data_sync")
         sub_parsers = subparser.add_subparsers(title="dbt-coves data-sync commands", dest="task")
         SnowflakeDestinationDataSyncTask.register_parser(sub_parsers, base_subparser)
+        RedshiftDestinationDataSyncTask.register_parser(sub_parsers, base_subparser)
         cls.arg_parser = subparser
         return subparser

--- a/dbt_coves/tasks/data_sync/redshift.py
+++ b/dbt_coves/tasks/data_sync/redshift.py
@@ -1,8 +1,8 @@
 import os
 
-from base import BaseDataSyncTask
-
 from dbt_coves.utils.tracking import trackable
+
+from .base import BaseDataSyncTask
 
 DLT_PREFIX = "DESTINATION__REDSHIFT__CREDENTIALS__"
 DATA_SYNC_PREFIX = "DATA_SYNC_REDSHIFT_"

--- a/dbt_coves/tasks/data_sync/redshift.py
+++ b/dbt_coves/tasks/data_sync/redshift.py
@@ -4,28 +4,25 @@ from base import BaseDataSyncTask
 
 from dbt_coves.utils.tracking import trackable
 
-DLT_PREFIX = "DESTINATION__SNOWFLAKE__CREDENTIALS__"
-DATA_SYNC_PREFIX = "DATA_SYNC_SNOWFLAKE_"
+DLT_PREFIX = "DESTINATION__REDSHIFT__CREDENTIALS__"
+DATA_SYNC_PREFIX = "DATA_SYNC_REDSHIFT_"
 
 
-class SnowflakeDestination(object):
+class RedshiftDestination(object):
     def set_credentials(self) -> None:
         """Dlt destination credentials can be set either by modifying the secrets file or
         by setting environment variables. Setting environment variables.
         """
-        for key in ["DATABASE", "PASSWORD", "WAREHOUSE", "ROLE"]:
+        for key in ["DATABASE", "PASSWORD", "USER", "HOST"]:
             value = os.environ.get(f"{DATA_SYNC_PREFIX}{key}")
             assert value, f"Environment variable {DATA_SYNC_PREFIX}{key} is not defined"
             os.environ[f"{DLT_PREFIX}{key}"] = value
         value = os.environ.get(f"{DATA_SYNC_PREFIX}USER")
         assert value, f"Environment variable {DATA_SYNC_PREFIX}USER is not defined"
         os.environ[f"{DLT_PREFIX}USERNAME"] = value
-        value = os.environ.get(f"{DATA_SYNC_PREFIX}ACCOUNT")
-        assert value, f"Environment variable {DATA_SYNC_PREFIX}ACCOUNT is not defined"
-        os.environ[f"{DLT_PREFIX}HOST"] = value
 
 
-class SnowflakeDestinationDataSyncTask(BaseDataSyncTask):
+class RedshiftDestinationDataSyncTask(BaseDataSyncTask):
     """
     Task that extracts airbyte sources, connections and destinations and stores them as json files
     """
@@ -33,12 +30,12 @@ class SnowflakeDestinationDataSyncTask(BaseDataSyncTask):
     @classmethod
     def register_parser(cls, sub_parsers, base_subparser):
         subparser = sub_parsers.add_parser(
-            "snowflake",
+            "redshift",
             parents=[base_subparser],
-            help="""Loads data into Snowflake""",
+            help="""Loads data into Redshift""",
         )
         subparser.add_argument("--source", help="Source database name", required=True)
-        subparser.set_defaults(cls=cls, which="snowflake")
+        subparser.set_defaults(cls=cls, which="redshift")
         return subparser
 
     @trackable
@@ -50,5 +47,5 @@ class SnowflakeDestinationDataSyncTask(BaseDataSyncTask):
         return 0
 
     def get_destination_instance(self) -> None:
-        self.destination = "snowflake"
-        self.destination_instance = SnowflakeDestination()
+        self.destination = "redshift"
+        self.destination_instance = RedshiftDestination()

--- a/dbt_coves/tasks/data_sync/snowflake.py
+++ b/dbt_coves/tasks/data_sync/snowflake.py
@@ -25,7 +25,7 @@ class SnowflakeDestination(object):
         os.environ[f"{DLT_PREFIX}HOST"] = value
 
 
-class SnowflakeDestinationDataSyncTask(BaseDataSyncTask):
+class SnowflakeDataSyncTask(BaseDataSyncTask):
     """
     Task that extracts airbyte sources, connections and destinations and stores them as json files
     """
@@ -37,16 +37,21 @@ class SnowflakeDestinationDataSyncTask(BaseDataSyncTask):
             parents=[base_subparser],
             help="""Loads data into Snowflake""",
         )
+        subparser.add_argument("--tables", help="List of tables to dump", required=False)
         subparser.add_argument("--source", help="Source database name", required=True)
         subparser.set_defaults(cls=cls, which="snowflake")
         return subparser
 
+    def get_config_value(self, key):
+        return self.coves_config.integrated["data_sync"][self.args.task][key]
+
     @trackable
     def run(self):
+        self.tables = self.get_config_value("tables")
         self.get_source_connection_string()
         self.get_destination_instance()
         self.destination_instance.set_credentials()
-        self.load_entire_database()
+        self.perform_sync()
         return 0
 
     def get_destination_instance(self) -> None:

--- a/dbt_coves/tasks/data_sync/snowflake.py
+++ b/dbt_coves/tasks/data_sync/snowflake.py
@@ -1,8 +1,8 @@
 import os
 
-from base import BaseDataSyncTask
-
 from dbt_coves.utils.tracking import trackable
+
+from .base import BaseDataSyncTask
 
 DLT_PREFIX = "DESTINATION__SNOWFLAKE__CREDENTIALS__"
 DATA_SYNC_PREFIX = "DATA_SYNC_SNOWFLAKE_"

--- a/dbt_coves/utils/flags.py
+++ b/dbt_coves/utils/flags.py
@@ -138,6 +138,7 @@ class DbtCovesFlags:
             "git": {"no_prompt": False},
         }
         self.dbt = {"command": None, "project_dir": None, "virtualenv": None, "cleanup": False}
+        self.data_sync = {"redshift": {"tables": []}, "snowflake": {"tables": []}}
 
     def parse_args(self, cli_args: List[str] = list()) -> None:
         args = sys.argv[1:]
@@ -398,3 +399,15 @@ class DbtCovesFlags:
                     self.dbt["virtualenv"] = self.args.virtualenv
                 if self.args.cleanup:
                     self.dbt["cleanup"] = self.args.cleanup
+
+            # data sync
+            if self.args.cls.__name__ == "RedshiftDataSyncTask":
+                if self.args.tables:
+                    self.data_sync["redshift"]["tables"] = [
+                        table.strip() for table in self.args.tables.split(",")
+                    ]
+            if self.args.cls.__name__ == "SnowflakeDataSyncTask":
+                if self.args.tables:
+                    self.data_sync["snowflake"]["tables"] = [
+                        table.strip() for table in self.args.tables.split(",")
+                    ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -864,6 +864,23 @@ files = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.2.14"
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "Deprecated-1.2.14-py2.py3-none-any.whl", hash = "sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c"},
+    {file = "Deprecated-1.2.14.tar.gz", hash = "sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"},
+]
+
+[package.dependencies]
+wrapt = ">=1.10,<2"
+
+[package.extras]
+dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "sphinx (<2)", "tox"]
+
+[[package]]
 name = "dictdiffer"
 version = "0.9.0"
 description = "Dictdiffer is a library that helps you to diff and patch dictionaries."
@@ -893,18 +910,19 @@ files = [
 
 [[package]]
 name = "dlt"
-version = "0.4.10"
+version = "0.3.25"
 description = "dlt is an open-source python-first scalable data loading library that does not require any backend to run."
 optional = false
-python-versions = "<3.13,>=3.8.1"
+python-versions = ">=3.8.1,<3.13"
 files = [
-    {file = "dlt-0.4.10-py3-none-any.whl", hash = "sha256:f9af939f1d9196489528c6ecbdc5a618f1a897d83cc9d52a8ab3bbeada836c64"},
-    {file = "dlt-0.4.10.tar.gz", hash = "sha256:e394443543f5038ba260b2932780cf9f5c82bc7ff2535e3b1752e8ca28b2cf61"},
+    {file = "dlt-0.3.25-py3-none-any.whl", hash = "sha256:c15e291f3fd19dd1f6a05ea53d3c955c6622bd23424cd24c0b31e29eb31d9bf9"},
+    {file = "dlt-0.3.25.tar.gz", hash = "sha256:49d50180df909a9d262828afbcec74eff4c5d30efa71f62d1c9e9db9c5862628"},
 ]
 
 [package.dependencies]
 astunparse = ">=1.6.3"
 click = ">=7.1"
+deprecated = ">=1.2.9"
 fsspec = ">=2022.4.0"
 gitpython = ">=3.1.29"
 giturlparse = ">=0.10.0"
@@ -912,7 +930,7 @@ hexbytes = ">=0.2.2"
 humanize = ">=4.4.0"
 jsonpath-ng = ">=1.5.3"
 makefun = ">=1.15.0"
-orjson = {version = ">=3.6.7,<=3.9.10", markers = "platform_python_implementation != \"PyPy\""}
+orjson = {version = ">=3.6.7", markers = "platform_python_implementation != \"PyPy\""}
 packaging = ">=21.1"
 pathvalidate = ">=2.5.2"
 pendulum = ">=2.1.2"
@@ -925,34 +943,31 @@ requirements-parser = ">=0.5.0"
 semver = ">=2.13.0"
 setuptools = ">=65.6.0"
 simplejson = ">=3.17.5"
+SQLAlchemy = ">=1.4.0"
 tenacity = ">=8.0.2"
 tomlkit = ">=0.11.3"
 typing-extensions = ">=4.0.0"
 tzdata = ">=2022.1"
-win-precise-time = {version = ">=1.4.2", markers = "os_name == \"nt\""}
 
 [package.extras]
-athena = ["botocore (>=1.28)", "pyarrow (>=12.0.0)", "pyathena (>=2.9.6)", "s3fs (>=2022.4.0)"]
+athena = ["botocore (>=1.28)", "pyarrow (>=8.0.0)", "pyathena (>=2.9.6)", "s3fs (>=2022.4.0)"]
 az = ["adlfs (>=2022.4.0)"]
-bigquery = ["gcsfs (>=2022.4.0)", "google-cloud-bigquery (>=2.26.0)", "grpcio (>=1.50.0)", "pyarrow (>=12.0.0)"]
+bigquery = ["gcsfs (>=2022.4.0)", "google-cloud-bigquery (>=2.26.0)", "grpcio (>=1.50.0)", "pyarrow (>=8.0.0)"]
 cli = ["cron-descriptor (>=1.2.32)", "pipdeptree (>=2.9.0,<2.10)"]
-clickhouse = ["adlfs (>=2022.4.0)", "clickhouse-connect (>=0.7.7)", "clickhouse-driver (>=0.2.7)", "gcsfs (>=2022.4.0)", "pyarrow (>=12.0.0)", "s3fs (>=2022.4.0)"]
-databricks = ["databricks-sql-connector (>=2.9.3,<3.0.0)"]
-dbt = ["dbt-athena-community (>=1.2.0)", "dbt-bigquery (>=1.2.0)", "dbt-core (>=1.2.0)", "dbt-databricks (>=1.7.3)", "dbt-duckdb (>=1.2.0)", "dbt-redshift (>=1.2.0)", "dbt-snowflake (>=1.2.0)"]
-dremio = ["pyarrow (>=12.0.0)"]
-duckdb = ["duckdb (>=0.10.0,<0.11.0)", "duckdb (>=0.6.1,<0.10.0)"]
+dbt = ["dbt-athena-community (>=1.2.0)", "dbt-bigquery (>=1.2.0)", "dbt-core (>=1.2.0)", "dbt-duckdb (>=1.2.0)", "dbt-redshift (>=1.2.0)", "dbt-snowflake (>=1.2.0)"]
+duckdb = ["duckdb (>=0.6.1,<0.10.0)"]
 filesystem = ["botocore (>=1.28)", "s3fs (>=2022.4.0)"]
 gcp = ["gcsfs (>=2022.4.0)", "google-cloud-bigquery (>=2.26.0)", "grpcio (>=1.50.0)"]
 gs = ["gcsfs (>=2022.4.0)"]
-motherduck = ["duckdb (>=0.10.0,<0.11.0)", "duckdb (>=0.6.1,<0.10.0)", "pyarrow (>=12.0.0)"]
+motherduck = ["duckdb (>=0.6.1,<0.10.0)", "pyarrow (>=8.0.0)"]
 mssql = ["pyodbc (>=4.0.39,<5.0.0)"]
-parquet = ["pyarrow (>=12.0.0)"]
+parquet = ["pyarrow (>=8.0.0)"]
 postgres = ["psycopg2-binary (>=2.9.1)", "psycopg2cffi (>=2.9.0)"]
+pydantic = ["pydantic (>=1.10,<2.0)"]
 qdrant = ["qdrant-client[fastembed] (>=1.6.4,<2.0.0)"]
 redshift = ["psycopg2-binary (>=2.9.1)", "psycopg2cffi (>=2.9.0)"]
 s3 = ["botocore (>=1.28)", "s3fs (>=2022.4.0)"]
-snowflake = ["snowflake-connector-python (>=3.5.0)"]
-synapse = ["adlfs (>=2022.4.0)", "pyarrow (>=12.0.0)", "pyodbc (>=4.0.39,<5.0.0)"]
+snowflake = ["snowflake-connector-python[pandas] (>=3.1.1)"]
 weaviate = ["weaviate-client (>=3.22)"]
 
 [[package]]
@@ -4895,25 +4910,82 @@ files = [
 test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 
 [[package]]
-name = "win-precise-time"
-version = "1.4.2"
-description = ""
+name = "wrapt"
+version = "1.16.0"
+description = "Module for decorators, wrappers and monkey patching."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 files = [
-    {file = "win-precise-time-1.4.2.tar.gz", hash = "sha256:89274785cbc5f2997e01675206da3203835a442c60fd97798415c6b3c179c0b9"},
-    {file = "win_precise_time-1.4.2-cp310-cp310-win32.whl", hash = "sha256:7fa13a2247c2ef41cd5e9b930f40716eacc7fc1f079ea72853bd5613fe087a1a"},
-    {file = "win_precise_time-1.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:bb8e44b0fc35fde268e8a781cdcd9f47d47abcd8089465d2d1d1063976411c8e"},
-    {file = "win_precise_time-1.4.2-cp311-cp311-win32.whl", hash = "sha256:59272655ad6f36910d0b585969402386fa627fca3be24acc9a21be1d550e5db8"},
-    {file = "win_precise_time-1.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:0897bb055f19f3b4336e2ba6bee0115ac20fd7ec615a6d736632e2df77f8851a"},
-    {file = "win_precise_time-1.4.2-cp312-cp312-win32.whl", hash = "sha256:0210dcea88a520c91de1708ae4c881e3c0ddc956daa08b9eabf2b7c35f3109f5"},
-    {file = "win_precise_time-1.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:85670f77cc8accd8f1e6d05073999f77561c23012a9ee988cbd44bb7ce655062"},
-    {file = "win_precise_time-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:3e23693201a0fc6ca39f016871e2581e20c91123734bd48a69259f8c8724eedb"},
-    {file = "win_precise_time-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:07ef644d1bb7705039bc54abfe4b45e99e8dc326dfd1dad5831dab19670508cb"},
-    {file = "win_precise_time-1.4.2-cp38-cp38-win32.whl", hash = "sha256:0a953b00772f205602fa712ef68387b8fb213a30b267ae310aa56bf17605e11b"},
-    {file = "win_precise_time-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:b5d83420925beca302b386b19c3e7414ada84b47b42f0680207f1508917a1731"},
-    {file = "win_precise_time-1.4.2-cp39-cp39-win32.whl", hash = "sha256:50d11a6ff92e1be96a8d4bee99ff6dc07a0ea0e2a392b0956bb2192e334f41ba"},
-    {file = "win_precise_time-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:3f510fa92d9c39ea533c983e1d62c7bc66fdf0a3e3c3bdda48d4ebb634ff7034"},
+    {file = "wrapt-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"},
+    {file = "wrapt-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020"},
+    {file = "wrapt-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440"},
+    {file = "wrapt-1.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487"},
+    {file = "wrapt-1.16.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf"},
+    {file = "wrapt-1.16.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72"},
+    {file = "wrapt-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0"},
+    {file = "wrapt-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136"},
+    {file = "wrapt-1.16.0-cp310-cp310-win32.whl", hash = "sha256:f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d"},
+    {file = "wrapt-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2"},
+    {file = "wrapt-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09"},
+    {file = "wrapt-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d"},
+    {file = "wrapt-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389"},
+    {file = "wrapt-1.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060"},
+    {file = "wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1"},
+    {file = "wrapt-1.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3"},
+    {file = "wrapt-1.16.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956"},
+    {file = "wrapt-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d"},
+    {file = "wrapt-1.16.0-cp311-cp311-win32.whl", hash = "sha256:66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362"},
+    {file = "wrapt-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89"},
+    {file = "wrapt-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b"},
+    {file = "wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36"},
+    {file = "wrapt-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73"},
+    {file = "wrapt-1.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809"},
+    {file = "wrapt-1.16.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b"},
+    {file = "wrapt-1.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81"},
+    {file = "wrapt-1.16.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9"},
+    {file = "wrapt-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c"},
+    {file = "wrapt-1.16.0-cp312-cp312-win32.whl", hash = "sha256:685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc"},
+    {file = "wrapt-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8"},
+    {file = "wrapt-1.16.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8"},
+    {file = "wrapt-1.16.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39"},
+    {file = "wrapt-1.16.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c"},
+    {file = "wrapt-1.16.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40"},
+    {file = "wrapt-1.16.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc"},
+    {file = "wrapt-1.16.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e"},
+    {file = "wrapt-1.16.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465"},
+    {file = "wrapt-1.16.0-cp36-cp36m-win32.whl", hash = "sha256:da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e"},
+    {file = "wrapt-1.16.0-cp36-cp36m-win_amd64.whl", hash = "sha256:6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966"},
+    {file = "wrapt-1.16.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593"},
+    {file = "wrapt-1.16.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292"},
+    {file = "wrapt-1.16.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5"},
+    {file = "wrapt-1.16.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf"},
+    {file = "wrapt-1.16.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228"},
+    {file = "wrapt-1.16.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f"},
+    {file = "wrapt-1.16.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c"},
+    {file = "wrapt-1.16.0-cp37-cp37m-win32.whl", hash = "sha256:9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c"},
+    {file = "wrapt-1.16.0-cp37-cp37m-win_amd64.whl", hash = "sha256:66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00"},
+    {file = "wrapt-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0"},
+    {file = "wrapt-1.16.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202"},
+    {file = "wrapt-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0"},
+    {file = "wrapt-1.16.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e"},
+    {file = "wrapt-1.16.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f"},
+    {file = "wrapt-1.16.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267"},
+    {file = "wrapt-1.16.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca"},
+    {file = "wrapt-1.16.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6"},
+    {file = "wrapt-1.16.0-cp38-cp38-win32.whl", hash = "sha256:c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b"},
+    {file = "wrapt-1.16.0-cp38-cp38-win_amd64.whl", hash = "sha256:490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41"},
+    {file = "wrapt-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2"},
+    {file = "wrapt-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb"},
+    {file = "wrapt-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8"},
+    {file = "wrapt-1.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c"},
+    {file = "wrapt-1.16.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a"},
+    {file = "wrapt-1.16.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664"},
+    {file = "wrapt-1.16.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f"},
+    {file = "wrapt-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537"},
+    {file = "wrapt-1.16.0-cp39-cp39-win32.whl", hash = "sha256:ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3"},
+    {file = "wrapt-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35"},
+    {file = "wrapt-1.16.0-py3-none-any.whl", hash = "sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1"},
+    {file = "wrapt-1.16.0.tar.gz", hash = "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d"},
 ]
 
 [[package]]
@@ -4951,4 +5023,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "43be31f52f69fbb540471ebd1beef50d0877a68a857695a2a3ec264f14a2c01b"
+content-hash = "f11da8d7004524386522b59ff700cfdedbcabc9597fcfe34b1591f8273824892"

--- a/poetry.lock
+++ b/poetry.lock
@@ -35,6 +35,17 @@ files = [
 ]
 
 [[package]]
+name = "ansicon"
+version = "1.89.0"
+description = "Python wrapper for loading Jason Hood's ANSICON"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ansicon-1.89.0-py2.py3-none-any.whl", hash = "sha256:f1def52d17f65c2c9682cf8370c03f541f410c1752d6a14029f97318e4b9dfec"},
+    {file = "ansicon-1.89.0.tar.gz", hash = "sha256:e4d039def5768a47e4afec8e89e83ec3ae5a26bf00ad851f914d1240b444d2b1"},
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 description = "Disable App Nap on macOS >= 10.9"
@@ -241,6 +252,22 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "blessed"
+version = "1.20.0"
+description = "Easy, practical library for making terminal apps, by providing an elegant, well-documented interface to Colors, Keyboard input, and screen Positioning capabilities."
+optional = false
+python-versions = ">=2.7"
+files = [
+    {file = "blessed-1.20.0-py2.py3-none-any.whl", hash = "sha256:0c542922586a265e699188e52d5f5ac5ec0dd517e5a1041d90d2bbf23f906058"},
+    {file = "blessed-1.20.0.tar.gz", hash = "sha256:2cdd67f8746e048f00df47a2880f4d6acbcdb399031b604e34ba8f71d5787680"},
+]
+
+[package.dependencies]
+jinxed = {version = ">=1.1.0", markers = "platform_system == \"Windows\""}
+six = ">=1.9.0"
+wcwidth = ">=0.1.4"
 
 [[package]]
 name = "boto3"
@@ -994,6 +1021,21 @@ files = [
 
 [package.dependencies]
 packaging = ">=20.9"
+
+[[package]]
+name = "enlighten"
+version = "1.12.4"
+description = "Enlighten Progress Bar"
+optional = false
+python-versions = "*"
+files = [
+    {file = "enlighten-1.12.4-py2.py3-none-any.whl", hash = "sha256:5c53c57441bc5986c1d02f2f539aead9d59a206783641953a49b8d995db6b584"},
+    {file = "enlighten-1.12.4.tar.gz", hash = "sha256:75f3d92b49e0ef5e454fc1a0f39dc0ab8f6d9946cbe534db3ded3010217d5b5f"},
+]
+
+[package.dependencies]
+blessed = ">=1.17.7"
+prefixed = ">=0.3.2"
 
 [[package]]
 name = "exceptiongroup"
@@ -1917,6 +1959,20 @@ PyYAML = "*"
 
 [package.extras]
 test = ["pytest", "pytest-cov"]
+
+[[package]]
+name = "jinxed"
+version = "1.2.1"
+description = "Jinxed Terminal Library"
+optional = false
+python-versions = "*"
+files = [
+    {file = "jinxed-1.2.1-py2.py3-none-any.whl", hash = "sha256:37422659c4925969c66148c5e64979f553386a4226b9484d910d3094ced37d30"},
+    {file = "jinxed-1.2.1.tar.gz", hash = "sha256:30c3f861b73279fea1ed928cfd4dfb1f273e16cd62c8a32acfac362da0f78f3f"},
+]
+
+[package.dependencies]
+ansicon = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "jmespath"
@@ -3041,6 +3097,17 @@ python-versions = ">=3.8,<4.0"
 files = [
     {file = "poetry_core-1.9.0-py3-none-any.whl", hash = "sha256:4e0c9c6ad8cf89956f03b308736d84ea6ddb44089d16f2adc94050108ec1f5a1"},
     {file = "poetry_core-1.9.0.tar.gz", hash = "sha256:fa7a4001eae8aa572ee84f35feb510b321bd652e5cf9293249d62853e1f935a2"},
+]
+
+[[package]]
+name = "prefixed"
+version = "0.7.1"
+description = "Prefixed alternative numeric library"
+optional = false
+python-versions = "*"
+files = [
+    {file = "prefixed-0.7.1-py2.py3-none-any.whl", hash = "sha256:530cb380c9d90f3436e68bddcde1aca6ea5babc6a4445ce692d7a605fa88efaf"},
+    {file = "prefixed-0.7.1.tar.gz", hash = "sha256:d10ac90acfc4cc14d82c1408b330b2fda85ed7cec2206a800d43899f8c385265"},
 ]
 
 [[package]]
@@ -5023,4 +5090,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.12"
-content-hash = "f11da8d7004524386522b59ff700cfdedbcabc9597fcfe34b1591f8273824892"
+content-hash = "a65c01d6fffca993b64d1c6e8766af57f35c6bc80acee3ad838a068618cdc0a5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ gitpython = "^3.1.31"
 mixpanel = "^4.10.0"
 black = "^23"
 isort = "^5.12.0"
-dlt = {extras = ["postgres"], version = "^0.4.8"}
+dlt = {extras = ["redshift"], version = "^0.3"}
 psycopg2-binary = "^2.9.9"
 sqlalchemy = "^1.4"
 pyyaml-include = "<2.0"
@@ -129,7 +129,7 @@ line-length = 100
 target-version=['py37', 'py38', 'py39', 'py310', 'py311']
 
 [tool.isort]
-known_third_party=["airflow", "black", "copier", "dbt", "dlt", "dotenv", "git", "google", "isort", "jinja2", "mixpanel", "pretty_errors", "pydantic", "pyfiglet", "pytest", "questionary", "redshift_connector", "requests", "rich", "ruamel", "slugify", "snowflake", "sqlalchemy", "typing_extensions", "yaml"]
+known_third_party=["airflow", "base", "black", "copier", "dbt", "dlt", "dotenv", "git", "google", "isort", "jinja2", "mixpanel", "pretty_errors", "pydantic", "pyfiglet", "pytest", "questionary", "redshift_connector", "requests", "rich", "ruamel", "slugify", "snowflake", "sqlalchemy", "typing_extensions", "yaml"]
 line_length=100
 multi_line_output=3
 include_trailing_comma=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ line-length = 100
 target-version=['py37', 'py38', 'py39', 'py310', 'py311']
 
 [tool.isort]
-known_third_party=["airflow", "base", "black", "copier", "dbt", "dlt", "dotenv", "git", "google", "isort", "jinja2", "mixpanel", "pretty_errors", "pydantic", "pyfiglet", "pytest", "questionary", "redshift_connector", "requests", "rich", "ruamel", "slugify", "snowflake", "sqlalchemy", "typing_extensions", "yaml"]
+known_third_party=["airflow", "black", "copier", "dbt", "dlt", "dotenv", "git", "google", "isort", "jinja2", "mixpanel", "pretty_errors", "pydantic", "pyfiglet", "pytest", "questionary", "redshift_connector", "requests", "rich", "ruamel", "slugify", "snowflake", "sqlalchemy", "typing_extensions", "yaml"]
 line_length=100
 multi_line_output=3
 include_trailing_comma=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dlt = {extras = ["redshift"], version = "^0.3"}
 psycopg2-binary = "^2.9.9"
 sqlalchemy = "^1.4"
 pyyaml-include = "<2.0"
+enlighten = "^1.12.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"


### PR DESCRIPTION
`dbt-coves data-sync` changes:
- add `enlighten` progress-bar support
- add Redshift support, `dbt-coves data-sync redshift`
- add `--tables "comma, separated, list, of, tables"` argument to limit data-sync to a specific set of tables