### PR TITLE
Fix #486: using env_var in Profiles.yml raised a LookupError

### DIFF
--- a/dbt_coves/tasks/base.py
+++ b/dbt_coves/tasks/base.py
@@ -80,6 +80,10 @@ class BaseConfiguredTask(ConfiguredTask, BaseTask):
         if (__dbt_major_version__, __dbt_minor_version__) < (1, 8):
             config = cls.ConfigType.from_args(args)
         else:
+            from dbt_common.clients.system import get_env
+            from dbt_common.context import set_invocation_context
+
+            set_invocation_context(get_env())
             config = RuntimeConfig.from_args(args)
         try:
             return cls(args, config)

--- a/tests/templates/profiles.yml.template
+++ b/tests/templates/profiles.yml.template
@@ -29,7 +29,7 @@ test_dbt_coves_snowflake:
     dev:
       account: {{ env_var('ACCOUNT_SNOWFLAKE')}}
       database: {{ env_var('DATABASE_SNOWFLAKE')}}
-      password: {{ env_var('PASSWORD_SNOWFLAKE')}}
+      password: {%raw%}"{{ env_var('PASSWORD_SNOWFLAKE')}}"{%endraw%}
       role: {{ env_var('ROLE_SNOWFLAKE')}}
       schema: {{ env_var('SCHEMA_SNOWFLAKE')}}
       threads: 1


### PR DESCRIPTION
This PR fixes #486 

Since `dbt-adapters` and `dbt-common` dedup (1.7 onwards), Env has to be [explicitly set](https://github.com/dbt-labs/dbt-common/blob/main/dbt_common/context.py#L47) to dbt-common's `Invocation Context`.
