### PR TITLE
Fix metrics badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dbt-coves
 
+[![PyPI version fury.io](https://badge.fury.io/py/dbt-coves.svg)](https://pypi.python.org/pypi/dbt-coves/) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dbt_coves) [![Build](https://github.com/datacoves/dbt-coves/actions/workflows/main_ci.yml/badge.svg)](https://github.com/datacoves/dbt-coves/actions/workflows/main_ci.yml/badge.svg)
+
 ## Brought to you by your friends at Datacoves
 
 <picture>
@@ -90,12 +92,7 @@ If you're interested in contributing to the development of dbt-coves, please ref
 
 # Metrics
 
+[![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/datacoves/dbt-coves/graphs/commit-activity)
-[![PyPI version
-fury.io](https://badge.fury.io/py/dbt-coves.svg)](https://pypi.python.org/pypi/dbt-coves/)
-[![Code
-Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dbt_coves)
-[![Build](https://github.com/datacoves/dbt-coves/actions/workflows/main_ci.yml/badge.svg)](https://github.com/datacoves/dbt-coves/actions/workflows/main_ci.yml/badge.svg)
 [![Maintainability](https://api.codeclimate.com/v1/badges/1e6a887de605ef8e0eca/maintainability)](https://codeclimate.com/github/datacoves/dbt-coves/maintainability)
 [![Downloads](https://pepy.tech/badge/dbt-coves)](https://pepy.tech/project/dbt-coves)

--- a/README.md
+++ b/README.md
@@ -95,11 +95,7 @@ If you're interested in contributing to the development of dbt-coves, please ref
 fury.io](https://badge.fury.io/py/dbt-coves.svg)](https://pypi.python.org/pypi/dbt-coves/)
 [![Code
 Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
-[![Imports:
-python](https://img.shields.io/badge/python-3.8%20%7C%203.9-blue)](https://img.shields.io/badge/python-3.8%20%7C%203.9-blue)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dbt_coves)
 [![Build](https://github.com/datacoves/dbt-coves/actions/workflows/main_ci.yml/badge.svg)](https://github.com/datacoves/dbt-coves/actions/workflows/main_ci.yml/badge.svg)
-
-<!-- [![codecov](https://codecov.io/gh/datacoves/dbt-coves/branch/main/graph/badge.svg?token=JB0E0LZDW1)](https://codecov.io/gh/datacoves/dbt-coves) -->
-
 [![Maintainability](https://api.codeclimate.com/v1/badges/1e6a887de605ef8e0eca/maintainability)](https://codeclimate.com/github/datacoves/dbt-coves/maintainability)
 [![Downloads](https://pepy.tech/badge/dbt-coves)](https://pepy.tech/project/dbt-coves)


### PR DESCRIPTION
This PR replaces the old `n python badges` for [PyPI badges](https://shields.io/badges/py-pi-python-version) and moves PyPI, Python and Build badges to the top of README.