### PR TITLE
Add INDIRECT_SELECTION to global parser

### DIFF
--- a/dbt_coves/core/main.py
+++ b/dbt_coves/core/main.py
@@ -212,6 +212,15 @@ base_subparser.add_argument(
     help="Show resource names without spaces",
     dest="REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES",
 )
+base_subparser.add_argument(
+    "--indirect-selection",
+    type=str,
+    default="eager",
+    help="Choose which tests to select that are adjacent to selected resources. "
+    "Eager is most inclusive, cautious is most exclusive, and buildable is in between. "
+    "Empty includes no tests at all.",
+    dest="INDIRECT_SELECTION",
+)
 
 
 sub_parsers = parser.add_subparsers(title="dbt-coves commands", dest="task")


### PR DESCRIPTION
This PR adds the new INDIRECT_SELECTION flag for projects that have related tests, setting the default to "eager" per dbt docs: https://docs.getdbt.com/reference/global-configs/indirect-selection