### PR TITLE
DCV-2857 changes to blue-green run

### DIFF
--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -155,7 +155,7 @@ class DataSyncModel(BaseModel):
 
 
 class BlueGreenModel(BaseModel):
-    service_connection_name: Optional[str] = ""
+    prod_db_env_var: Optional[str] = ""
     staging_database: Optional[str] = ""
     staging_suffix: Optional[str] = ""
     drop_staging_db_at_start: Optional[bool] = False
@@ -262,7 +262,7 @@ class DbtCovesConfig:
         "load.fivetran.secrets_key",
         "data_sync.redshift.tables",
         "data_sync.snowflake.tables",
-        "blue_green.service_connection_name",
+        "blue_green.prod_db_env_var",
         "blue_green.staging_database",
         "blue_green.staging_suffix",
         "blue_green.drop_staging_db_at_start",

--- a/dbt_coves/core/main.py
+++ b/dbt_coves/core/main.py
@@ -295,7 +295,8 @@ def main(parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = li
             console.print(
                 "[red]The process was killed by the OS due to running out of memory.[/red]"
             )
-        console.print(f"[red]:cross_mark:[/red] {cpe.stderr}")
+        if cpe.stderr:
+            console.print(f"[red]:cross_mark:[/red] {cpe.stderr}")
 
         return cpe.returncode
     except Exception as ex:

--- a/dbt_coves/utils/flags.py
+++ b/dbt_coves/utils/flags.py
@@ -139,7 +139,7 @@ class DbtCovesFlags:
         self.dbt = {"command": None, "project_dir": None, "virtualenv": None, "cleanup": False}
         self.data_sync = {"redshift": {"tables": []}, "snowflake": {"tables": []}}
         self.blue_green = {
-            "service_connection_name": None,
+            "prod_db_env_var": None,
             "staging_database": None,
             "staging_suffix": None,
             "drop_staging_db_at_start": False,
@@ -421,8 +421,8 @@ class DbtCovesFlags:
 
             # blue green
             if self.args.cls.__name__ == "BlueGreenTask":
-                if self.args.service_connection_name:
-                    self.blue_green["service_connection_name"] = self.args.service_connection_name
+                if self.args.prod_db_env_var:
+                    self.blue_green["prod_db_env_var"] = self.args.prod_db_env_var
                 if self.args.staging_database:
                     self.blue_green["staging_database"] = self.args.staging_database
                 if self.args.staging_suffix:

--- a/tests/blue_green/profiles.yml
+++ b/tests/blue_green/profiles.yml
@@ -2,7 +2,7 @@ default:
   outputs:
     dev:
       account: "{{ env_var('DATACOVES__DBT_COVES_TEST__ACCOUNT') }}"
-      database: DBT_COVES_TEST_STAGING
+      database: "{{ env_var('DATACOVES__DBT_COVES_TEST__DATABASE') }}"
       password: "{{ env_var('DATACOVES__DBT_COVES_TEST__PASSWORD') }}"
       role: "{{ env_var('DATACOVES__DBT_COVES_TEST__ROLE') }}"
       schema: TESTS_BLUE_GREEN

--- a/tests/blue_green_test.py
+++ b/tests/blue_green_test.py
@@ -39,7 +39,7 @@ except KeyError:
 @pytest.fixture(scope="class")
 def snowflake_connection(request):
     # Check env vars
-    assert "DATACOVES__DBT_COVES_TEST__USER" in os.environ
+    assert "DATACOVES__DBT_COVES_TEST__DATABASE" in os.environ
     assert "DATACOVES__DBT_COVES_TEST__PASSWORD" in os.environ
     assert "DATACOVES__DBT_COVES_TEST__ACCOUNT" in os.environ
     assert "DATACOVES__DBT_COVES_TEST__WAREHOUSE" in os.environ
@@ -103,8 +103,8 @@ class TestBlueGreen:
             str(FIXTURE_DIR),
             "--profiles-dir",
             str(FIXTURE_DIR),
-            "--service-connection-name",
-            self.production_database,
+            "--prod-db-env-var",
+            "DATACOVES__DBT_COVES_TEST__DATABASE",
             "--keep-staging-db-on-success",
         ]
         if DBT_COVES_SETTINGS.get("drop_staging_db_at_start"):


### PR DESCRIPTION
This PR extends `dbt-coves blue-green` to make it usable at CI time.

To run at CI time, simply don't pass `--service-connection-name` (Datacoves-exclusive feature)