### PR TITLE
DCV-2893 dbt-coves setup: add new --template-url

### DIFF
--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -132,6 +132,7 @@ class LoadModel(BaseModel):
 class SetupModel(BaseModel):
     no_prompt: Optional[bool] = False
     quiet: Optional[bool] = False
+    setup_template_url: Optional[str] = "https://github.com/datacoves/setup_template.git"
 
 
 class RunDbtModel(BaseModel):
@@ -241,6 +242,7 @@ class DbtCovesConfig:
         "load.airbyte.secrets_key",
         "setup.no_prompt",
         "setup.quiet",
+        "setup.setup_template_url",
         "dbt.command",
         "dbt.project_dir",
         "dbt.virtualenv",

--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -132,7 +132,7 @@ class LoadModel(BaseModel):
 class SetupModel(BaseModel):
     no_prompt: Optional[bool] = False
     quiet: Optional[bool] = False
-    setup_template_url: Optional[str] = "https://github.com/datacoves/setup_template.git"
+    template_url: Optional[str] = "https://github.com/datacoves/setup_template.git"
 
 
 class RunDbtModel(BaseModel):
@@ -242,7 +242,7 @@ class DbtCovesConfig:
         "load.airbyte.secrets_key",
         "setup.no_prompt",
         "setup.quiet",
-        "setup.setup_template_url",
+        "setup.template_url",
         "dbt.command",
         "dbt.project_dir",
         "dbt.virtualenv",

--- a/dbt_coves/tasks/setup/main.py
+++ b/dbt_coves/tasks/setup/main.py
@@ -53,6 +53,10 @@ class SetupTask(NonDbtBaseTask):
             help="Skip rendering results",
             default=False,
         )
+        ext_subparser.add_argument(
+            "--setup-template-url",
+            help="URL to the setup template repository",
+        )
         ext_subparser.set_defaults(cls=cls, which="setup")
         cls.arg_parser = ext_subparser
         return ext_subparser
@@ -136,7 +140,7 @@ class SetupTask(NonDbtBaseTask):
         for service in services:
             self.copier_context[service] = True
         copier.run_auto(
-            src_path="git@github.com:datacoves/setup_template.git",
+            src_path=self.get_config_value("setup_template_url"),
             dst_path=self.repo_path,
             data=self.copier_context,
             quiet=self.get_config_value("quiet"),

--- a/dbt_coves/tasks/setup/main.py
+++ b/dbt_coves/tasks/setup/main.py
@@ -54,7 +54,7 @@ class SetupTask(NonDbtBaseTask):
             default=False,
         )
         ext_subparser.add_argument(
-            "--setup-template-url",
+            "--template-url",
             help="URL to the setup template repository",
         )
         ext_subparser.set_defaults(cls=cls, which="setup")
@@ -140,7 +140,7 @@ class SetupTask(NonDbtBaseTask):
         for service in services:
             self.copier_context[service] = True
         copier.run_auto(
-            src_path=self.get_config_value("setup_template_url"),
+            src_path=self.get_config_value("template_url"),
             dst_path=self.repo_path,
             data=self.copier_context,
             quiet=self.get_config_value("quiet"),

--- a/dbt_coves/utils/flags.py
+++ b/dbt_coves/utils/flags.py
@@ -133,7 +133,7 @@ class DbtCovesFlags:
             "template": "https://github.com/datacoves/cookiecutter-dbt.git",
             "current-dir": False,
         }
-        self.setup = {"no_prompt": False, "setup_template_url": None}
+        self.setup = {"no_prompt": False, "template_url": None}
         self.dbt = {"command": None, "project_dir": None, "virtualenv": None, "cleanup": False}
         self.data_sync = {"redshift": {"tables": []}, "snowflake": {"tables": []}}
         self.blue_green = {
@@ -393,8 +393,8 @@ class DbtCovesFlags:
                     self.setup["no_prompt"] = self.args.no_prompt
                 if self.args.quiet:
                     self.setup["quiet"] = self.args.quiet
-                if self.args.setup_template_url:
-                    self.setup["setup_template_url"] = self.args.setup_template_url
+                if self.args.template_url:
+                    self.setup["template_url"] = self.args.template_url
 
             # run dbt
             if self.args.cls.__name__ == "RunDbtTask":

--- a/dbt_coves/utils/flags.py
+++ b/dbt_coves/utils/flags.py
@@ -133,9 +133,7 @@ class DbtCovesFlags:
             "template": "https://github.com/datacoves/cookiecutter-dbt.git",
             "current-dir": False,
         }
-        self.setup = {
-            "no_prompt": False,
-        }
+        self.setup = {"no_prompt": False, "setup_template_url": None}
         self.dbt = {"command": None, "project_dir": None, "virtualenv": None, "cleanup": False}
         self.data_sync = {"redshift": {"tables": []}, "snowflake": {"tables": []}}
         self.blue_green = {
@@ -395,6 +393,8 @@ class DbtCovesFlags:
                     self.setup["no_prompt"] = self.args.no_prompt
                 if self.args.quiet:
                     self.setup["quiet"] = self.args.quiet
+                if self.args.setup_template_url:
+                    self.setup["setup_template_url"] = self.args.setup_template_url
 
             # run dbt
             if self.args.cls.__name__ == "RunDbtTask":


### PR DESCRIPTION
This PR adds --setup-template-url to `dbt-coves setup`, defaulting to Datacoves' setup_template git http url.