### PR TITLE
Retain numerical precision and scale for Snowflake columns

### DIFF
--- a/dbt_coves/tasks/generate/base.py
+++ b/dbt_coves/tasks/generate/base.py
@@ -159,12 +159,21 @@ class BaseGenerateTask(BaseConfiguredTask):
         }
         return data
 
-    def get_default_metadata_item(self, name, type="varchar", description=""):
+    def get_default_metadata_item(
+        self,
+        name,
+        type="varchar",
+        description="",
+        numeric_precision=None,
+        numeric_scale=None,
+    ):
         return {
             "name": name,
             "id": slugify(name, separator="_"),
             "type": type,
             "description": description,
+            "numeric_precision": numeric_precision,
+            "numeric_scale": numeric_scale,
         }
 
     def get_metadata(self):
@@ -240,11 +249,22 @@ class BaseGenerateTask(BaseConfiguredTask):
                     new_col["name"] = col.name
                     new_col["id"] = slugify(col.name, separator="_")
             if not new_col:
+                numeric_precision = None
+                numeric_scale = None
                 if "BigQuery" in self.adapter.__class__.__name__:
                     col_type = col.data_type
+                if "Snowflake" in self.adapter.__class__.__name__:
+                    col_type = col.dtype
+                    numeric_precision = col.numeric_precision
+                    numeric_scale = col.numeric_scale
                 else:
                     col_type = col.dtype
-                new_col = self.get_default_metadata_item(col.name, type=col_type)
+                new_col = self.get_default_metadata_item(
+                    col.name,
+                    type=col_type,
+                    numeric_precision=numeric_precision,
+                    numeric_scale=numeric_scale,
+                )
             metadata_cols.append(new_col)
         return metadata_cols
 


### PR DESCRIPTION
`dbt-coves`' default behaviour of including an explicit cast for column in model staging files causes decimals to be dropped in Snowflake:

```sql
select
  2.5,
  2.5::number

-- Return 2.5, 3
```

This is because `number` by default has a scale of 0 — i.e., it accepts no digits after the decimal and Snowflake rounds the number. This, in turn, **implicitly converts all float values to integers**.

To solve this, I've updated the `BaseGenerateTask.get_default_metadata_item` and `get_metadata_columns` to retain the `numeric_precision` and `numeric_scale` of `SnowflakeColumn` and also updated the `staging_model.sql` template to preserve the precision and scale when casting number columns.

I didn't apply the same logic to any other adapters (in either `BaseGenerateTask` or the template) because I don't have any way of testing them.

A cursory glance at the docs for both [Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_Numeric_types201.html#r_Numeric_types201-decimal-or-numeric-type) and [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#parameterized_decimal_type) indicates that both platforms also default to a scale of 0 if it's not explicitly defined and would result in the same implicit conversion to an integer.

**Redshift:**

>  scale
>
>    ...The maximum scale is 37.

**BigQuery:**

> A NUMERIC or DECIMAL type with a maximum precision of P and maximum scale of S, where P and S are INT64 types. **S is interpreted to be 0 if unspecified.**

However, I also don't know what their respective adapters return from `get_columns_in_relation`, and I can't check myself, so my edits are exclusive to Snowflake.

I'd be happy to contribute any tests for this as needed, if you can point me in the right direction for how you'd like me to set up the test.