### PR TITLE
[Dcv-3851] dbt-coves fails on modern Airbyte due to endpoint changes

### DIFF
--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -82,7 +82,7 @@ class GenerateModel(BaseModel):
 class ExtractAirbyteModel(BaseModel):
     path: Optional[str] = ""
     host: Optional[str] = ""
-    port: Optional[str] = ""
+    api_key: Optional[str] = ""
 
 
 class ExtractFivetranModel(BaseModel):
@@ -95,7 +95,7 @@ class ExtractFivetranModel(BaseModel):
 class LoadAirbyteModel(BaseModel):
     path: Optional[str] = ""
     host: Optional[str] = ""
-    port: Optional[str] = ""
+    api_key: Optional[str] = ""
     secrets_path: Optional[str] = ""
     secrets_manager: Optional[str] = ""
     secrets_url: Optional[str] = ""
@@ -230,10 +230,10 @@ class DbtCovesConfig:
         "generate.airflow_dags.secrets_key",
         "extract.airbyte.path",
         "extract.airbyte.host",
-        "extract.airbyte.port",
+        "extract.airbyte.api_key",
         "load.airbyte.path",
         "load.airbyte.host",
-        "load.airbyte.port",
+        "load.airbyte.api_key",
         "load.airbyte.secrets_path",
         "load.airbyte.secrets_manager",
         "load.airbyte.secrets_url",

--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -82,6 +82,7 @@ class GenerateModel(BaseModel):
 class ExtractAirbyteModel(BaseModel):
     path: Optional[str] = ""
     host: Optional[str] = ""
+    port: Optional[str] = ""
     api_key: Optional[str] = ""
 
 
@@ -95,6 +96,7 @@ class ExtractFivetranModel(BaseModel):
 class LoadAirbyteModel(BaseModel):
     path: Optional[str] = ""
     host: Optional[str] = ""
+    port: Optional[str] = ""
     api_key: Optional[str] = ""
     secrets_path: Optional[str] = ""
     secrets_manager: Optional[str] = ""
@@ -230,9 +232,11 @@ class DbtCovesConfig:
         "generate.airflow_dags.secrets_key",
         "extract.airbyte.path",
         "extract.airbyte.host",
+        "extract.airbyte.port",
         "extract.airbyte.api_key",
         "load.airbyte.path",
         "load.airbyte.host",
+        "load.airbyte.port",
         "load.airbyte.api_key",
         "load.airbyte.secrets_path",
         "load.airbyte.secrets_manager",

--- a/dbt_coves/tasks/extract/airbyte.py
+++ b/dbt_coves/tasks/extract/airbyte.py
@@ -53,7 +53,12 @@ class ExtractAirbyteTask(BaseExtractTask):
         subparser.add_argument(
             "--host",
             type=str,
-            help="Airbyte's API host, i.e. 'http://airbyte-server:8000'",
+            help="Airbyte's API host, i.e. 'http://airbyte-server'",
+        )
+        subparser.add_argument(
+            "--port",
+            type=str,
+            help="Airbyte's API port, i.e. '8006'",
         )
         subparser.add_argument(
             "--api-key",
@@ -73,6 +78,7 @@ class ExtractAirbyteTask(BaseExtractTask):
 
         extract_destination = self.get_config_value("path")
         airbyte_host = self.get_config_value("host")
+        airbyte_port = self.get_config_value("port")
         airbyte_api_key = self.get_config_value("api_key")
 
         if not extract_destination or not airbyte_host:
@@ -88,7 +94,9 @@ class ExtractAirbyteTask(BaseExtractTask):
         self.destinations_extract_destination = os.path.abspath(destinations_path)
         self.sources_extract_destination = os.path.abspath(sources_path)
 
-        self.airbyte_api = AirbyteApiCaller(airbyte_host, api_key=airbyte_api_key or None)
+        self.airbyte_api = AirbyteApiCaller(
+            airbyte_host, api_port=airbyte_port or None, api_key=airbyte_api_key or None
+        )
 
         console.print(
             "Extracting Airbyte's [b]Source[/b], [b]Destination[/b] and [b]Connection[/b]"

--- a/dbt_coves/tasks/extract/airbyte.py
+++ b/dbt_coves/tasks/extract/airbyte.py
@@ -13,10 +13,8 @@ from dbt_coves.utils.tracking import trackable
 
 from .base import BaseExtractTask
 
-# from dbt_coves.utils import airbyte_api
-
 console = Console()
-NON_EXTRACT_KEYS = ["icon", "breakingChange"]
+NON_EXTRACT_KEYS = ["icon", "breakingChange", "createdAt", "updatedAt"]
 
 
 class AirbyteExtractorException(Exception):
@@ -24,21 +22,19 @@ class AirbyteExtractorException(Exception):
 
 
 class ExtractAirbyteTask(BaseExtractTask):
+    """
+    Task that extracts airbyte sources, connections and destinations and stores them as json files
+    """
+
     def _normalize_filename(self, name: str) -> str:
         """
         Normalize a string to be safe for filenames: lowercase, replace spaces and unsafe chars
         with underscores.
         """
         name = name.lower()
-        # Replace spaces and any non-alphanumeric character with underscore
         name = re.sub(r"[^a-z0-9\-]+", "_", name)
-        # Remove leading/trailing underscores
         name = name.strip("_")
         return name
-
-    """
-    Task that extracts airbyte sources, connections and destinations and stores them as json files
-    """
 
     @classmethod
     def register_parser(cls, sub_parsers, base_subparser):
@@ -57,12 +53,12 @@ class ExtractAirbyteTask(BaseExtractTask):
         subparser.add_argument(
             "--host",
             type=str,
-            help="Airbyte's API hostname, i.e. 'http://airbyte-server'",
+            help="Airbyte's API host, i.e. 'http://airbyte-server:8000'",
         )
         subparser.add_argument(
-            "--port",
+            "--api-key",
             type=str,
-            help="Airbyte's API port, i.e. '8001'",
+            help="Airbyte's API key for Bearer token auth (optional for open OSS instances)",
         )
         subparser.set_defaults(cls=cls, which="airbyte")
         return subparser
@@ -77,10 +73,10 @@ class ExtractAirbyteTask(BaseExtractTask):
 
         extract_destination = self.get_config_value("path")
         airbyte_host = self.get_config_value("host")
-        airbyte_port = self.get_config_value("port")
+        airbyte_api_key = self.get_config_value("api_key")
 
-        if not extract_destination or not airbyte_host or not airbyte_port:
-            raise MissingArgumentException(["path", "host", "port"], self.coves_config)
+        if not extract_destination or not airbyte_host:
+            raise MissingArgumentException(["path", "host"], self.coves_config)
 
         extract_destination = pathlib.Path(extract_destination)
 
@@ -92,7 +88,7 @@ class ExtractAirbyteTask(BaseExtractTask):
         self.destinations_extract_destination = os.path.abspath(destinations_path)
         self.sources_extract_destination = os.path.abspath(sources_path)
 
-        self.airbyte_api = AirbyteApiCaller(airbyte_host, airbyte_port)
+        self.airbyte_api = AirbyteApiCaller(airbyte_host, api_key=airbyte_api_key or None)
 
         console.print(
             "Extracting Airbyte's [b]Source[/b], [b]Destination[/b] and [b]Connection[/b]"
@@ -102,17 +98,18 @@ class ExtractAirbyteTask(BaseExtractTask):
         sources_path.mkdir(exist_ok=True, parents=True)
         destinations_path.mkdir(exist_ok=True, parents=True)
         connections_path.mkdir(exist_ok=True, parents=True)
-        for airbyte_source in self.airbyte_api.airbyte_sources_list:
+
+        for airbyte_source in self.airbyte_api.sources_list:
             source_id = airbyte_source["sourceId"]
             source_json = self._get_airbyte_source_from_id(source_id)
             self._save_json_source(source_json)
 
-        for airbyte_destination in self.airbyte_api.airbyte_destinations_list:
+        for airbyte_destination in self.airbyte_api.destinations_list:
             destination_id = airbyte_destination["destinationId"]
             destination_json = self._get_airbyte_destination_from_id(destination_id)
             self._save_json_destination(destination_json)
 
-        for airbyte_conn in self.airbyte_api.airbyte_connections_list:
+        for airbyte_conn in self.airbyte_api.connections_list:
             self._save_json_connection(airbyte_conn)
 
         if len(self.extraction_results["sources"]) >= 1:
@@ -129,75 +126,124 @@ class ExtractAirbyteTask(BaseExtractTask):
     def dbt_packages_exist(self, dbt_project_path):
         return glob.glob(f"{str(dbt_project_path)}/dbt_packages")
 
-    def _get_airbyte_destination_definition_from_id(self, definition_id):
-        req_body = {
-            "destinationDefinitionId": definition_id,
-            "workspaceId": self.airbyte_api.airbyte_workspace_id,
-        }
-        return self.airbyte_api.api_call(
-            self.airbyte_api.api_endpoints["GET_OBJECTS"].format(
-                obj="destination_definition_specifications"
-            ),
-            req_body,
+    def _get_definition_id_by_connector_type(self, connector_type, definitions):
+        """
+        Find a connector definition ID by matching the connector type string
+        (e.g. "postgres") against the docker repository name (e.g. "airbyte/source-postgres").
+        """
+        for definition in definitions:
+            repo = definition.get("dockerRepository", "")
+            repo_suffix = repo.split("/")[-1]  # e.g. "source-postgres"
+            expected = f"source-{connector_type}"
+            if repo_suffix == expected or repo_suffix == f"destination-{connector_type}":
+                def_id = definition.get("sourceDefinitionId") or definition.get(
+                    "destinationDefinitionId"
+                )
+                return def_id
+            # Also try a direct connectorType field if the API provides one
+            if definition.get("connectorType") == connector_type:
+                return definition.get("sourceDefinitionId") or definition.get(
+                    "destinationDefinitionId"
+                )
+        return None
+
+    def _get_airbyte_destination_definition_spec(self, destination_type):
+        definition_id = self._get_definition_id_by_connector_type(
+            destination_type, self.airbyte_api.destination_definitions
         )
+        if not definition_id:
+            return None
+        return self.airbyte_api.get_destination_spec(definition_id)
 
-    def _get_airbyte_destination_from_id(self, destinationId):
-        """
-        Get the complete Destination object from it's ID
-        """
-        for destination in self.airbyte_api.airbyte_destinations_list:
-            if destination["destinationId"] == destinationId:
-                # Grab Source definition ID
-                destination_definition = self._get_airbyte_destination_definition_from_id(
-                    destination["destinationDefinitionId"]
-                )
-                # Get Secret fields for source definition
-                airbyte_secret_fields = self._get_airbyte_secret_fields_for_definition(
-                    destination_definition
-                )
-                # Ensure all airbyte_secret fields are effectively hidden
-                destination["connectionConfiguration"] = self._hide_configuration_secret_fields(
-                    destination["connectionConfiguration"], airbyte_secret_fields
-                )
+    def _get_airbyte_source_definition_spec(self, source_type):
+        definition_id = self._get_definition_id_by_connector_type(
+            source_type, self.airbyte_api.source_definitions
+        )
+        if not definition_id:
+            return None
+        return self.airbyte_api.get_source_spec(definition_id)
 
-                # Add object definition version
+    def _get_airbyte_destination_from_id(self, destination_id):
+        """Get the complete Destination object from its ID."""
+        for destination in self.airbyte_api.destinations_list:
+            if destination["destinationId"] == destination_id:
+                destination_type = destination.get("destinationType", "")
+                spec = self._get_airbyte_destination_definition_spec(destination_type)
+
+                if spec:
+                    airbyte_secret_fields = self._get_airbyte_secret_fields_for_definition(spec)
+                    destination["configuration"] = self._hide_configuration_secret_fields(
+                        destination.get("configuration", {}), airbyte_secret_fields
+                    )
+                else:
+                    console.print(
+                        f"[yellow]Warning:[/yellow] Could not retrieve spec for destination type "
+                        f"'{destination_type}' — secrets will not be masked"
+                    )
+
                 destination["connectorVersion"] = self._get_connector_version(
-                    "destinationDefinitionId",
-                    self.airbyte_api.destination_definitions,
-                    destination_definition["destinationDefinitionId"],
+                    destination_type, self.airbyte_api.destination_definitions, "destination"
                 )
-
                 return destination
+
         raise AirbyteExtractorException(
             "Airbyte extract error: there is no Airbyte"
-            f"Destination for id [red]{destinationId}[/red]"
+            f"Destination for id [red]{destination_id}[/red]"
         )
 
-    def _get_connector_version(self, lookup_field, definitions_list, definition_id):
-        for definition in definitions_list:
-            if definition[lookup_field] == definition_id:
-                return definition["dockerImageTag"]
-        raise AirbyteExtractorException(f"No connector definition found for ID {definition_id}")
+    def _get_connector_version(self, connector_type, definitions, obj_type):
+        """
+        Look up dockerImageTag from the definitions list by matching connector type
+        against the docker repository name.
+        """
+        for definition in definitions:
+            repo = definition.get("dockerRepository", "")
+            repo_suffix = repo.split("/")[-1]
+            expected_suffix = f"{obj_type}-{connector_type}"
+            if repo_suffix == expected_suffix:
+                return definition.get("dockerImageTag", "unknown")
+            if definition.get("connectorType") == connector_type:
+                return definition.get("dockerImageTag", "unknown")
+        console.print(
+            f"[yellow]Warning:[/yellow] Could not find connector version for {obj_type} "
+            f"type '{connector_type}'"
+        )
+        return "unknown"
 
-    def _get_airbyte_source_definition_from_id(self, definition_id):
-        req_body = {
-            "sourceDefinitionId": definition_id,
-            "workspaceId": self.airbyte_api.airbyte_workspace_id,
-        }
-        return self.airbyte_api.api_call(
-            self.airbyte_api.api_endpoints["GET_OBJECTS"].format(
-                obj="source_definition_specifications"
-            ),
-            req_body,
+    def _get_airbyte_source_from_id(self, source_id):
+        """Get the complete Source object from its ID."""
+        for source in self.airbyte_api.sources_list:
+            if source["sourceId"] == source_id:
+                source_type = source.get("sourceType", "")
+                spec = self._get_airbyte_source_definition_spec(source_type)
+
+                if spec:
+                    airbyte_secret_fields = self._get_airbyte_secret_fields_for_definition(spec)
+                    source["configuration"] = self._hide_configuration_secret_fields(
+                        source.get("configuration", {}), airbyte_secret_fields
+                    )
+                else:
+                    console.print(
+                        f"[yellow]Warning:[/yellow] Could not retrieve spec for source type "
+                        f"'{source_type}' — secrets will not be masked"
+                    )
+
+                source["connectorVersion"] = self._get_connector_version(
+                    source_type, self.airbyte_api.source_definitions, "source"
+                )
+                return source
+
+        raise AirbyteExtractorException(
+            f"Airbyte extract error: there is no Airbyte Source for id [red]{source_id}[/red]"
         )
 
-    def _hide_configuration_secret_fields(self, connection_configuration, airbyte_secret_fields):
-        for k, v in connection_configuration.items():
+    def _hide_configuration_secret_fields(self, configuration, airbyte_secret_fields):
+        for k, v in configuration.items():
             if isinstance(v, dict):
                 self._hide_configuration_secret_fields(v, airbyte_secret_fields)
             elif k in airbyte_secret_fields:
-                connection_configuration[k] = "**********"
-        return connection_configuration
+                configuration[k] = "**********"
+        return configuration
 
     def _get_airbyte_secret_fields_for_definition(
         self, definition, dict_name=None, secret_fields=[]
@@ -213,41 +259,8 @@ class ExtractAirbyteTask(BaseExtractTask):
             return secret_fields
         except KeyError as e:
             raise AirbyteExtractorException(
-                "There was an error searching secret fields for"
-                f"{definition['connectionSpecification']['title']}:"
-                f"{e}"
+                f"There was an error searching secret fields for definition: {e}"
             )
-
-    def _get_airbyte_source_from_id(self, source_id):
-        """
-        Get the complete Source object from it's ID
-        """
-        for source in self.airbyte_api.airbyte_sources_list:
-            if source["sourceId"] == source_id:
-                # Grab Source definition ID
-                source_definition = self._get_airbyte_source_definition_from_id(
-                    source["sourceDefinitionId"]
-                )
-                # Get Secret fields for source definition
-                airbyte_secret_fields = self._get_airbyte_secret_fields_for_definition(
-                    source_definition
-                )
-                # Ensure all airbyte_secret fields are effectively hidden
-                source["connectionConfiguration"] = self._hide_configuration_secret_fields(
-                    source["connectionConfiguration"], airbyte_secret_fields
-                )
-
-                # Add object definition version
-                source["connectorVersion"] = self._get_connector_version(
-                    "sourceDefinitionId",
-                    self.airbyte_api.source_definitions,
-                    source_definition["sourceDefinitionId"],
-                )
-
-                return source
-        raise AirbyteExtractorException(
-            f"Airbyte extract error: there is no Airbyte Source for id [red]{source_id}[/red]"
-        )
 
     def _remove_unnecessary_fields(self, json_object):
         json_copy = json_object.copy()
@@ -267,16 +280,13 @@ class ExtractAirbyteTask(BaseExtractTask):
 
     def _save_json_connection(self, connection: dict):
         connection = copy(connection)
-        connection.pop("connectionId")
+        connection.pop("connectionId", None)
 
         connection_source_name = self._get_airbyte_source_from_id(connection["sourceId"])["name"]
         connection_destination_name = self._get_airbyte_destination_from_id(
             connection["destinationId"]
         )["name"]
 
-        # Once we used the source and destination IDs,
-        # they are no longer required and don't need to be saved
-        # Instead, they are replaced with their respective names
         connection.pop("sourceId", None)
         connection.pop("destinationId", None)
         connection.pop("sourceCatalogId", None)
@@ -287,30 +297,24 @@ class ExtractAirbyteTask(BaseExtractTask):
         )
 
         path = os.path.join(self.connections_extract_destination, filename)
-
         self._save_json(path, connection)
         self.extraction_results["connections"].add(filename)
 
     def _save_json_destination(self, destination):
         destination = copy(destination)
-
-        destination.pop("destinationDefinitionId", None)
-        destination.pop("workspaceId", None)
         destination.pop("destinationId", None)
+        destination.pop("workspaceId", None)
         filename = f"{self._normalize_filename(destination['name'])}.json"
         path = os.path.join(self.destinations_extract_destination, filename)
-
         self._save_json(path, destination)
         self.extraction_results["destinations"].add(filename)
 
     def _save_json_source(self, source):
         source = copy(source)
-        source.pop("sourceDefinitionId", None)
-        source.pop("workspaceId", None)
         source.pop("sourceId", None)
+        source.pop("workspaceId", None)
         filename = f"{self._normalize_filename(source['name'])}.json"
         path = os.path.join(self.sources_extract_destination, filename)
-
         self._save_json(path, source)
         self.extraction_results["sources"].add(filename)
 

--- a/dbt_coves/tasks/extract/airbyte.py
+++ b/dbt_coves/tasks/extract/airbyte.py
@@ -178,15 +178,11 @@ class ExtractAirbyteTask(BaseExtractTask):
                 destination_type = destination.get("destinationType", "")
                 spec = self._get_airbyte_destination_definition_spec(destination_type)
 
+                # We may or may not get secrets information from Airbyte.
                 if spec:
                     airbyte_secret_fields = self._get_airbyte_secret_fields_for_definition(spec)
                     destination["configuration"] = self._hide_configuration_secret_fields(
                         destination.get("configuration", {}), airbyte_secret_fields
-                    )
-                else:
-                    console.print(
-                        f"[yellow]Warning:[/yellow] Could not retrieve spec for destination type "
-                        f"'{destination_type}' — secrets will not be masked"
                     )
 
                 destination["connectorVersion"] = self._get_connector_version(
@@ -202,7 +198,7 @@ class ExtractAirbyteTask(BaseExtractTask):
     def _get_connector_version(self, connector_type, definitions, obj_type):
         """
         Look up dockerImageTag from the definitions list by matching connector type
-        against the docker repository name.
+        against the docker repository name, if any.
         """
         for definition in definitions:
             repo = definition.get("dockerRepository", "")
@@ -212,10 +208,6 @@ class ExtractAirbyteTask(BaseExtractTask):
                 return definition.get("dockerImageTag", "unknown")
             if definition.get("connectorType") == connector_type:
                 return definition.get("dockerImageTag", "unknown")
-        console.print(
-            f"[yellow]Warning:[/yellow] Could not find connector version for {obj_type} "
-            f"type '{connector_type}'"
-        )
         return "unknown"
 
     def _get_airbyte_source_from_id(self, source_id):
@@ -225,15 +217,11 @@ class ExtractAirbyteTask(BaseExtractTask):
                 source_type = source.get("sourceType", "")
                 spec = self._get_airbyte_source_definition_spec(source_type)
 
+                # Try to get secrets information, if there is any.
                 if spec:
                     airbyte_secret_fields = self._get_airbyte_secret_fields_for_definition(spec)
                     source["configuration"] = self._hide_configuration_secret_fields(
                         source.get("configuration", {}), airbyte_secret_fields
-                    )
-                else:
-                    console.print(
-                        f"[yellow]Warning:[/yellow] Could not retrieve spec for source type "
-                        f"'{source_type}' — secrets will not be masked"
                     )
 
                 source["connectorVersion"] = self._get_connector_version(

--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -371,6 +371,10 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
                 output = self.generate_task_output(name, conf, is_task_taskgroup=True)
                 task_group_output.extend(output)
 
+        if len(task_group_output) == 2:
+            # No tasks were added — emit pass to keep the function body valid
+            task_group_output.append(f"{' ' * 8}pass # XXX dbt-coves did not receive a task here\n")
+
         tg_variable_name = f"tg_{tg_name}"
         task_group_output.append(f"{' ' * 4}{tg_variable_name} = {tg_name}()\n")
         self.generated_groups[tg_name] = tg_variable_name

--- a/dbt_coves/tasks/generate/airflow_generators/airbyte.py
+++ b/dbt_coves/tasks/generate/airflow_generators/airbyte.py
@@ -19,16 +19,20 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
         self,
         host: str = "http://localhost",
         port: str = "8000",
+        api_key: str = "",
         connection_ids: List[str] = [],
         airbyte_conn_id: str = "",
     ):
         self.host = host
         self.port = port
+        self.api_key = api_key
         self.airbyte_conn_id = airbyte_conn_id
         self.connection_ids = connection_ids
         self.ignored_source_tables = []
         self.imports = ["airflow.providers.airbyte.operators.airbyte.AirbyteTriggerSyncOperator"]
-        self.api_caller = AirbyteApiCaller(self.host, api_port=self.port)
+        self.api_caller = AirbyteApiCaller(
+            self.host, api_port=self.port or None, api_key=self.api_key or None
+        )
         self.airbyte_connections = self.api_caller.connections_list
         self.connections_should_exist = False
 
@@ -163,6 +167,7 @@ class AirbyteDbtGenerator(AirbyteGenerator, BaseDbtGenerator):
         self,
         host: str = "http://localhost",
         port: str = "8000",
+        api_key: str = "",
         dbt_project_path: str = "",
         virtualenv_path: str = "",
         run_dbt_compile: bool = False,
@@ -170,7 +175,9 @@ class AirbyteDbtGenerator(AirbyteGenerator, BaseDbtGenerator):
         run_dbt_deps: bool = False,
         airbyte_conn_id: str = "",
     ):
-        AirbyteGenerator.__init__(self, host=host, port=port, airbyte_conn_id=airbyte_conn_id)
+        AirbyteGenerator.__init__(
+            self, host=host, port=port, api_key=api_key, airbyte_conn_id=airbyte_conn_id
+        )
         BaseDbtGenerator.__init__(
             self,
             dbt_project_path,

--- a/dbt_coves/tasks/generate/airflow_generators/airbyte.py
+++ b/dbt_coves/tasks/generate/airflow_generators/airbyte.py
@@ -104,7 +104,7 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
         airbyte_tables = []
         connection_ids = []
         for conn in list(
-            filter(lambda conn: conn.get("status") == "active", self.airbyte_connections)
+            filter(lambda conn: conn.get("status") != "deprecated", self.airbyte_connections)
         ):
             # Handle both old syncCatalog and new configurations API formats
             catalog = conn.get("syncCatalog") or conn.get("configurations", {})

--- a/dbt_coves/tasks/generate/airflow_generators/airbyte.py
+++ b/dbt_coves/tasks/generate/airflow_generators/airbyte.py
@@ -28,8 +28,8 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
         self.connection_ids = connection_ids
         self.ignored_source_tables = []
         self.imports = ["airflow.providers.airbyte.operators.airbyte.AirbyteTriggerSyncOperator"]
-        self.api_caller = AirbyteApiCaller(self.host, self.port)
-        self.airbyte_connections = self.api_caller.airbyte_connections_list
+        self.api_caller = AirbyteApiCaller(self.host, api_port=self.port)
+        self.airbyte_connections = self.api_caller.connections_list
         self.connections_should_exist = False
 
     def validate_ids_in_airbyte(self, connection_ids):
@@ -62,14 +62,14 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
 
     def _get_airbyte_destination(self, id):
         """Given a destination id, returns the destination payload"""
-        for destination in self.api_caller.airbyte_destinations_list:
+        for destination in self.api_caller.destinations_list:
             if destination["destinationId"] == id:
                 return destination
         raise AirbyteGeneratorException(f"Airbyte error: there are no destinations for id {id}")
 
     def _get_airbyte_source(self, id):
         """Get the complete Source object from it's ID"""
-        for source in self.api_caller.airbyte_sources_list:
+        for source in self.api_caller.sources_list:
             if source["sourceId"] == id:
                 return source
         raise AirbyteGeneratorException(
@@ -77,22 +77,24 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
         )
 
     def _get_connection_schema(self, conn, destination_config):
-        """Given an airybte connection, returns a schema name"""
+        """Given an airbyte connection, returns a schema name"""
         namespace_definition = conn["namespaceDefinition"]
+        custom_format_values = {"customformat", "custom_format"}
 
         if namespace_definition == "source" or (
-            conn["namespaceDefinition"] == "customformat"
+            namespace_definition in custom_format_values
             and conn["namespaceFormat"] == "${SOURCE_NAMESPACE}"
         ):
             source = self._get_airbyte_source(conn["sourceId"])
-            if "schema" in source["connectionConfiguration"]:
-                return source["connectionConfiguration"]["schema"].lower()
+            source_config = source.get("configuration", source.get("connectionConfiguration", {}))
+            if "schema" in source_config:
+                return source_config["schema"].lower()
             else:
                 return None
         elif namespace_definition == "destination":
             return destination_config["schema"].lower()
         else:
-            if namespace_definition == "customformat":
+            if namespace_definition in custom_format_values:
                 return conn["namespaceFormat"].lower()
 
     def get_pipeline_connection_ids(self, db: str, schema: str, table: str) -> str:
@@ -104,14 +106,21 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
         for conn in list(
             filter(lambda conn: conn.get("status") == "active", self.airbyte_connections)
         ):
-            for stream in conn["syncCatalog"]["streams"]:
-                # look for the table
-                airbyte_table = stream["stream"]["name"].lower()
+            # Handle both old syncCatalog and new configurations API formats
+            catalog = conn.get("syncCatalog") or conn.get("configurations", {})
+            streams = catalog.get("streams", [])
+            for stream in streams:
+                # Old format: {"stream": {"name": ...}, "config": {...}}
+                # New format: {"name": ..., "syncMode": ...}
+                airbyte_table = (
+                    stream.get("stream", {}).get("name") or stream.get("name", "")
+                ).lower()
                 airbyte_tables.append(airbyte_table)
                 if airbyte_table == table.replace("_airbyte_raw_", ""):
-                    destination_config = self._get_airbyte_destination(conn["destinationId"])[
-                        "connectionConfiguration"
-                    ]
+                    destination = self._get_airbyte_destination(conn["destinationId"])
+                    destination_config = destination.get(
+                        "configuration", destination.get("connectionConfiguration", {})
+                    )
 
                     # match database
                     if (

--- a/dbt_coves/tasks/load/airbyte.py
+++ b/dbt_coves/tasks/load/airbyte.py
@@ -427,6 +427,76 @@ class LoadAirbyteTask(BaseLoadTask):
 
         return self._create_destination(exported_json_data)
 
+    SYNC_MODE_MAP = {
+        ("full_refresh", "overwrite"): "full_refresh_overwrite",
+        ("full_refresh", "append"): "full_refresh_append",
+        ("incremental", "append"): "incremental_append",
+        ("incremental", "append_dedup"): "incremental_deduped_history",
+    }
+
+    NAMESPACE_DEFINITION_MAP = {
+        "customformat": "custom_format",
+        "nsformat": "custom_format",
+    }
+
+    def _normalize_connection_fields(self, connection):
+        """Normalize field values that changed between the old internal API and the public API."""
+        ns_def = connection.get("namespaceDefinition")
+        if ns_def in self.NAMESPACE_DEFINITION_MAP:
+            connection["namespaceDefinition"] = self.NAMESPACE_DEFINITION_MAP[ns_def]
+        if connection.get("prefix") == "":
+            connection.pop("prefix")
+        return connection
+
+    def _normalize_connection_catalog(self, connection):
+        """
+        Convert syncCatalog (old internal API) to configurations (public API).
+        Skips deselected streams. Maps combined syncMode+destinationSyncMode to
+        the single syncMode string the public API expects.
+        """
+        sync_catalog = connection.pop("syncCatalog", None)
+        if sync_catalog is None or "configurations" in connection:
+            return connection
+
+        streams = []
+        for entry in sync_catalog.get("streams", []):
+            stream = entry.get("stream", {})
+            config = entry.get("config", {})
+            if not config.get("selected", True):
+                continue
+            sync_mode = config.get("syncMode", "full_refresh")
+            dest_sync_mode = config.get("destinationSyncMode", "overwrite")
+            new_mode = self.SYNC_MODE_MAP.get(
+                (sync_mode, dest_sync_mode), f"{sync_mode}_{dest_sync_mode}"
+            )
+            stream_config = {"name": stream.get("name"), "syncMode": new_mode}
+            if stream.get("namespace"):
+                stream_config["streamNamespace"] = stream["namespace"]
+            if config.get("cursorField"):
+                stream_config["cursorField"] = config["cursorField"]
+            if config.get("primaryKey"):
+                stream_config["primaryKey"] = config["primaryKey"]
+            streams.append(stream_config)
+
+        connection["configurations"] = {"streams": streams}
+        return connection
+
+    def _normalize_connection_schedule(self, connection):
+        """
+        Convert flat scheduleType/scheduleData (old internal API) to the
+        nested schedule object the public API expects.
+        """
+        schedule_type = connection.pop("scheduleType", None)
+        schedule_data = connection.pop("scheduleData", None)
+        if schedule_type and "schedule" not in connection:
+            schedule = {"scheduleType": schedule_type}
+            if schedule_data:
+                schedule["cronExpression"] = schedule_data.get("cron", {}).get(
+                    "cronExpression"
+                ) or schedule_data.get("basicSchedule", {}).get("cronExpression")
+            connection["schedule"] = {k: v for k, v in schedule.items() if v is not None}
+        return connection
+
     def _create_connection(self, exported_json_data, source_id, destination_id):
         exported_json_data["sourceId"] = source_id
         exported_json_data["destinationId"] = destination_id
@@ -435,6 +505,10 @@ class LoadAirbyteTask(BaseLoadTask):
         )
         exported_json_data.pop("sourceName", None)
         exported_json_data.pop("destinationName", None)
+        exported_json_data.pop("operationIds", None)
+        exported_json_data = self._normalize_connection_fields(exported_json_data)
+        exported_json_data = self._normalize_connection_schedule(exported_json_data)
+        exported_json_data = self._normalize_connection_catalog(exported_json_data)
 
         try:
             response = self.airbyte_api.create_connection(exported_json_data)

--- a/dbt_coves/tasks/load/airbyte.py
+++ b/dbt_coves/tasks/load/airbyte.py
@@ -42,12 +42,12 @@ class LoadAirbyteTask(BaseLoadTask):
         subparser.add_argument(
             "--host",
             type=str,
-            help="Airbyte's API hostname, i.e. 'http://airbyte-server'",
+            help="Airbyte's API host, i.e. 'http://airbyte-server:8000'",
         )
         subparser.add_argument(
-            "--port",
+            "--api-key",
             type=str,
-            help="Airbyte's API port, i.e. '8001'",
+            help="Airbyte's API key for Bearer token auth (optional for open OSS instances)",
         )
         subparser.add_argument(
             "--secrets-path",
@@ -78,13 +78,13 @@ class LoadAirbyteTask(BaseLoadTask):
         }
         self.load_destination = self.get_config_value("path")
         self.airbyte_host = self.get_config_value("host")
-        self.airbyte_port = self.get_config_value("port")
+        self.airbyte_api_key = self.get_config_value("api_key")
         self.secrets_path = self.get_config_value("secrets_path")
         self.secrets_manager = self.get_config_value("secrets_manager")
 
-        if not (self.airbyte_host and self.airbyte_port and self.load_destination):
+        if not (self.airbyte_host and self.load_destination):
             raise AirbyteLoaderException(
-                "'path', 'host', and 'port' are required parameters in order to load Airbyte. "
+                "'path' and 'host' are required parameters in order to load Airbyte. "
                 "Please refer to 'dbt-coves load airbyte --help' for more information."
             )
         if self.secrets_path and self.secrets_manager:
@@ -108,17 +108,14 @@ class LoadAirbyteTask(BaseLoadTask):
         self.destinations_load_destination = os.path.abspath(path / "destinations")
         self.sources_load_destination = os.path.abspath(path / "sources")
 
-        self.airbyte_api = AirbyteApiCaller(self.airbyte_host, self.airbyte_port)
+        self.airbyte_api = AirbyteApiCaller(self.airbyte_host, api_key=self.airbyte_api_key or None)
 
         console.print(f"Loading DBT Sources into Airbyte from {os.path.abspath(path)}\n")
 
-        # Load all exported
         extracted_sources = self.retrieve_all_jsons_from_path(self.sources_load_destination)
-        # Create/update sources
         extracted_destinations = self.retrieve_all_jsons_from_path(
             self.destinations_load_destination
         )
-        # Create/update destinations
         extracted_connections = self.retrieve_all_jsons_from_path(self.connections_load_destination)
         for source in extracted_sources:
             self._create_or_update_source(source)
@@ -131,9 +128,6 @@ class LoadAirbyteTask(BaseLoadTask):
         return 0
 
     def _print_load_results(self):
-        """
-        Inform the user successful loading results
-        """
         console.print("[green][b]Load successful :heavy_check_mark:[/b][/green]")
         for obj_type, result_dict in self.loading_results.items():
             for action, results in result_dict.items():
@@ -157,15 +151,14 @@ class LoadAirbyteTask(BaseLoadTask):
 
     def _update_connection_config_secret_fields(
         self,
-        connection_configuration,
+        configuration,
         wildcard_pattern,
         secret_data,
         secret_target_name,
     ):
-        for k, v in connection_configuration.items():
+        for k, v in configuration.items():
             if wildcard_pattern == str(v):
-                # Replace 'v' for secret value
-                connection_configuration[k] = self._get_secret_value_for_field(
+                configuration[k] = self._get_secret_value_for_field(
                     secret_data, k, secret_target_name
                 )
             if isinstance(v, dict):
@@ -192,17 +185,15 @@ class LoadAirbyteTask(BaseLoadTask):
 
     def _get_secrets(self, exported_json_data, directory):
         """
-        Get Airbyte's connectionConfiguration keys and values for a specified filename
-        (source.json) and directory or object type: destinations/sources
+        Resolve masked secret fields in a source/destination's configuration.
         """
         try:
-            connection_configuration = exported_json_data["connectionConfiguration"]
+            configuration = exported_json_data.get("configuration", {})
             secret_target_name = slugify(exported_json_data["name"].lower())
-            # Regex: any string that contains only wildcards: from beginning to end
             wildcard_pattern = "**********"
 
             hidden_fields = list()
-            for config_field, value in connection_configuration.items():
+            for config_field, value in configuration.items():
                 if wildcard_pattern in str(value):
                     if isinstance(value, dict):
                         hidden_fields = self._discover_hidden_keys(
@@ -225,7 +216,6 @@ class LoadAirbyteTask(BaseLoadTask):
                     secret_data = target_secret_data["value"]
                 elif self.secrets_path:
                     secret_target_name = slugify(exported_json_data["name"].lower())
-                    # Get the secret file for that name
                     expected_secret_filepath = pathlib.Path(
                         self.secrets_path, directory, secret_target_name + ".json"
                     )
@@ -243,8 +233,8 @@ class LoadAirbyteTask(BaseLoadTask):
                         "secrets_path or secrets_manager flag must be provided"
                     )
 
-                connection_configuration = self._update_connection_config_secret_fields(
-                    connection_configuration,
+                self._update_connection_config_secret_fields(
+                    configuration,
                     wildcard_pattern,
                     secret_data,
                     secret_target_name,
@@ -256,93 +246,98 @@ class LoadAirbyteTask(BaseLoadTask):
                 f"[bold red]{exported_json_data['name']}[/bold red]: {e}"
             )
 
-    def _update_source_or_destination(self, exported_data, object_type):
+    def _update_source_or_destination(self, exported_data, object_type, object_id):
         update = True
-        conn_status = self._test_update_connection(exported_data, object_type)
-        if conn_status.get("status", "").lower() != "succeeded":
+        conn_status = self._test_existing_object(object_id, object_type)
+        if conn_status and conn_status.get("status", "").lower() != "succeeded":
             console.print(
-                f"Connection test for {exported_data['name']} failed:\n {conn_status['message']}"
+                f"Connection test for {exported_data['name']} failed:\n "
+                f"{conn_status.get('message', '')}"
             )
             update = questionary.confirm("Would you like to continue updating it?").ask()
         if update:
-            response = self.airbyte_api.api_call(
-                self.airbyte_api.api_endpoints["UPDATE_OBJECT"].format(obj=object_type),
-                exported_data,
-            )
-
+            update_body = {
+                "name": exported_data["name"],
+                "configuration": exported_data.get("configuration", {}),
+            }
+            if object_type == "sources":
+                response = self.airbyte_api.update_source(object_id, update_body)
+            else:
+                response = self.airbyte_api.update_destination(object_id, update_body)
             self._add_update_result(object_type, exported_data["name"])
             return response.get("sourceId", response.get("destinationId"))
 
     def _create_source_or_destination(self, exported_data, object_type):
-        create = True
-        response: dict = self.airbyte_api.api_call(
-            self.airbyte_api.api_endpoints["CREATE_OBJECT"].format(obj=object_type),
-            exported_data,
-        )
-        new_object_body = {}
         if object_type == "sources":
-            new_object_body = {"sourceId": response["sourceId"]}
-        elif object_type == "destinations":
-            new_object_body = {"destinationId": response["destinationId"]}
+            response = self.airbyte_api.create_source(exported_data)
+        else:
+            response = self.airbyte_api.create_destination(exported_data)
 
+        object_id = response.get("sourceId", response.get("destinationId", ""))
         object_name = response.get("name", "")
-        conn_status = self._test_created_object(new_object_body, object_type, object_name)
-        if conn_status.get("status", "").lower() != "succeeded":
+
+        conn_status = self._test_existing_object(object_id, object_type)
+        create = True
+        if conn_status and conn_status.get("status", "").lower() != "succeeded":
             console.print(
-                f"Connection test for {exported_data['name']} failed:\n {conn_status['message']}"
+                f"Connection test for {exported_data['name']} failed:\n "
+                f"{conn_status.get('message', '')}"
             )
             create = questionary.confirm("Would you like to continue creating it?").ask()
+
         if create:
-            self.airbyte_api.airbyte_destinations_list.append(response)
-            self.loading_results[object_type]["created"].append(exported_data["name"])
-            return response[next(iter(new_object_body))]
+            if object_type == "sources":
+                self.airbyte_api.sources_list.append(response)
+            else:
+                self.airbyte_api.destinations_list.append(response)
+            self.loading_results[object_type]["created"].append(object_name)
+            return object_id
         else:
-            self.airbyte_api.api_call(
-                self.airbyte_api.api_endpoints["DELETE_OBJECT"].format(obj=object_type),
-                new_object_body,
-            )
+            if object_type == "sources":
+                self.airbyte_api.delete_source(object_id)
+            else:
+                self.airbyte_api.delete_destination(object_id)
+
+    def _test_existing_object(self, object_id, object_type, timeout=30):
+        """Test connection for an existing source or destination by ID."""
+        console.print(f"Testing [yellow]{object_type[:-1]}[/yellow] connection")
+        try:
+            if object_type == "sources":
+                return self.airbyte_api.check_source(object_id, timeout=timeout)
+            else:
+                return self.airbyte_api.check_destination(object_id, timeout=timeout)
+        except AirbyteApiCallerException as e:
+            console.print(f"[yellow]Warning:[/yellow] Connection test failed: {e}")
+            return None
 
     def _create_source(self, exported_data):
-        exported_data.pop("connectorVersion")
+        exported_data.pop("connectorVersion", None)
         exported_data = self._get_secrets(exported_data, "sources")
-        exported_data["workspaceId"] = self.airbyte_api.airbyte_workspace_id
-        exported_data["sourceDefinitionId"] = self._get_source_definition_id_by_name(
-            exported_data.pop("sourceName")
-        )
+        exported_data["workspaceId"] = self.airbyte_api.workspace_id
+        # sourceType is already in the exported JSON from extract — no definition ID lookup needed
         self._create_source_or_destination(exported_data, "sources")
 
-    def _test_update_connection(self, data, obj_type):
-        console.print(f"Testing update for [yellow]{data.get('name', 'object')}[/yellow]")
-        return self.airbyte_api.api_call(
-            self.airbyte_api.api_endpoints["TEST_UPDATE"].format(obj=obj_type), data, timeout=30
-        )
-
     def _update_source(self, exported_data, source_id):
-        exported_data["sourceId"] = source_id
-        exported_data.pop("sourceName")
-        exported_data.pop("connectorVersion")
-
+        exported_data.pop("connectorVersion", None)
         exported_data = self._get_secrets(exported_data, "sources")
-        self._update_source_or_destination(exported_data, "sources")
+        self._update_source_or_destination(exported_data, "sources", source_id)
 
     def _sources_are_equivalent(self, exported_source, current_source):
-        current_source_copy = copy(current_source)
-        exported_source_copy = copy(exported_source)
-        exported_source_copy.pop("connectorVersion")
-        current_source_copy.pop("icon")
-        current_source_copy.pop("sourceId")
-        current_source_copy.pop("sourceDefinitionId")
-        current_source_copy.pop("workspaceId")
-        return current_source_copy == exported_source_copy
+        current_copy = copy(current_source)
+        exported_copy = copy(exported_source)
+        exported_copy.pop("connectorVersion", None)
+        # Strip server-managed fields from the live source before comparing
+        for field in ("sourceId", "workspaceId", "createdAt", "updatedAt", "icon"):
+            current_copy.pop(field, None)
+        return current_copy == exported_copy
 
     def _create_or_update_source(self, exported_json_data):
         """
-        Decide whether creating or updating an existing source\
-        (if it's name corresponds to an existing name in JSON exported configuration)
+        Decide whether to create or update a source based on name matching.
         """
         self._connector_versions_mismatch(exported_json_data, "source")
 
-        for src in self.airbyte_api.airbyte_sources_list:
+        for src in self.airbyte_api.sources_list:
             if exported_json_data["name"] == src["name"]:
                 if self._sources_are_equivalent(exported_json_data, src):
                     console.print(
@@ -354,101 +349,60 @@ class LoadAirbyteTask(BaseLoadTask):
 
         return self._create_source(exported_json_data)
 
-    def _get_destination_definition_id_by_name(self, destination_type_name):
-        """
-        Get destination definition ID by it's name
-        (File, Postgres, Snowflake, BigQuery, MariaDB, etc)
-        """
+    def _get_destination_definition_by_type(self, destination_type):
+        """Get destination definition by destinationType string."""
         for definition in self.airbyte_api.destination_definitions:
-            if definition["name"] == destination_type_name:
-                return definition["destinationDefinitionId"]
-        raise AirbyteLoaderException(
-            f"There is no destination definition for {destination_type_name}."
-            "Please review Airbyte's configuration"
-        )
-
-    def _get_destination_definition_by_name(self, destination_type_name):
-        """
-        Get destination definition ID by it's name
-        (File, Postgres, Snowflake, BigQuery, MariaDB, etc)
-        """
-        for definition in self.airbyte_api.destination_definitions:
-            if definition["name"] == destination_type_name:
+            repo = definition.get("dockerRepository", "")
+            repo_suffix = repo.split("/")[-1]
+            if repo_suffix == f"destination-{destination_type}":
+                return definition
+            if definition.get("connectorType") == destination_type:
                 return definition
         raise AirbyteLoaderException(
-            f"There is no destination definition for {destination_type_name}."
+            f"There is no destination definition for type '{destination_type}'. "
             "Please review Airbyte's configuration"
         )
 
-    def _get_source_definition_id_by_name(self, source_type_name):
-        """
-        Get destination definition ID by it's name
-        (File, Postgres, Snowflake, BigQuery, MariaDB, etc)
-        """
+    def _get_source_definition_by_type(self, source_type):
+        """Get source definition by sourceType string."""
         for definition in self.airbyte_api.source_definitions:
-            if definition["name"] == source_type_name:
-                return definition["sourceDefinitionId"]
-        raise AirbyteLoaderException(
-            f"There is no source definition for {source_type_name}."
-            "Please review Airbyte's configuration"
-        )
-
-    def _get_source_definition_by_name(self, source_type_name):
-        """
-        Get destination definition ID by it's name
-        (File, Postgres, Snowflake, BigQuery, MariaDB, etc)
-        """
-        for definition in self.airbyte_api.source_definitions:
-            if definition["name"] == source_type_name:
+            repo = definition.get("dockerRepository", "")
+            repo_suffix = repo.split("/")[-1]
+            if repo_suffix == f"source-{source_type}":
+                return definition
+            if definition.get("connectorType") == source_type:
                 return definition
         raise AirbyteLoaderException(
-            f"There is no source definition for {source_type_name}."
+            f"There is no source definition for type '{source_type}'. "
             "Please review Airbyte's configuration"
-        )
-
-    def _test_created_object(self, test_body, obj_type, obj_name):
-        console.print(f"Testing created {obj_type} [green]{obj_name}[/green]")
-        return self.airbyte_api.api_call(
-            self.airbyte_api.api_endpoints["TEST_CONNECTION"].format(obj=obj_type),
-            test_body,
-            timeout=30,
         )
 
     def _create_destination(self, exported_data):
-        exported_data.pop("connectorVersion")
+        exported_data.pop("connectorVersion", None)
         exported_data = self._get_secrets(exported_data, "destinations")
-        exported_data["workspaceId"] = self.airbyte_api.airbyte_workspace_id
-        exported_data["destinationDefinitionId"] = self._get_destination_definition_id_by_name(
-            exported_data.pop("destinationName")
-        )
+        exported_data["workspaceId"] = self.airbyte_api.workspace_id
         self._create_source_or_destination(exported_data, "destinations")
 
     def _update_destination(self, exported_data, destination_id):
-        exported_data.pop("destinationName")
-        exported_data["destinationId"] = destination_id
-        exported_data.pop("connectorVersion")
-
+        exported_data.pop("connectorVersion", None)
         exported_data = self._get_secrets(exported_data, "destinations")
-        self._update_source_or_destination(exported_data, "destinations")
+        self._update_source_or_destination(exported_data, "destinations", destination_id)
 
     def _destinations_are_equivalent(self, exported_destination, current_destination):
-        current_destination_copy = copy(current_destination)
-        exported_destination_copy = copy(exported_destination)
-        exported_destination_copy.pop("connectorVersion")
-        current_destination_copy.pop("destinationDefinitionId")
-        current_destination_copy.pop("destinationId")
-        current_destination_copy.pop("workspaceId")
-        current_destination_copy.pop("icon")
-        return current_destination_copy == exported_destination_copy
+        current_copy = copy(current_destination)
+        exported_copy = copy(exported_destination)
+        exported_copy.pop("connectorVersion", None)
+        for field in ("destinationId", "workspaceId", "createdAt", "updatedAt", "icon"):
+            current_copy.pop(field, None)
+        return current_copy == exported_copy
 
     def _create_or_update_destination(self, exported_json_data):
         """
-        Decide whether creating or updating an existing destination
-        (if it's name corresponds to an existing name in JSON exported configuration)
+        Decide whether to create or update a destination based on name matching.
         """
         self._connector_versions_mismatch(exported_json_data, "destination")
 
-        for destination in self.airbyte_api.airbyte_destinations_list:
+        for destination in self.airbyte_api.destinations_list:
             if exported_json_data["name"] == destination["name"]:
                 if self._destinations_are_equivalent(exported_json_data, destination):
                     console.print(
@@ -469,52 +423,35 @@ class LoadAirbyteTask(BaseLoadTask):
         connection_name = (
             f"{exported_json_data['sourceName']}-{exported_json_data['destinationName']}"
         )
-        exported_json_data.pop("sourceName")
-        exported_json_data.pop("destinationName")
+        exported_json_data.pop("sourceName", None)
+        exported_json_data.pop("destinationName", None)
 
         try:
-            response = self.airbyte_api.api_call(
-                self.airbyte_api.api_endpoints["CREATE_OBJECT"].format(obj="connections"),
-                exported_json_data,
-            )
+            response = self.airbyte_api.create_connection(exported_json_data)
             if response:
-                self.airbyte_api.airbyte_connections_list.append(response)
+                self.airbyte_api.connections_list.append(response)
                 return connection_name
         except AirbyteApiCallerException as ex:
             raise AirbyteApiCallerException(f"Could not create Airbyte connection: {ex}")
 
     def _delete_connection(self, connection_id):
         try:
-            conn_delete_req_body = {"connectionId": connection_id}
-            self.airbyte_api.api_call(
-                self.airbyte_api.api_endpoints["DELETE_OBJECT"].format(obj="connections"),
-                conn_delete_req_body,
-            )
+            self.airbyte_api.delete_connection(connection_id)
         except AirbyteApiCallerException:
             raise AirbyteLoaderException("Could not delete Airbyte connection for re-creation")
 
-    def _get_connection_id_by_table_name(self, table_name):
-        """
-        Given a table name, returns the corresponding airbyte connection
-        """
-        for conn in self.airbyte_api.airbyte_connections_list:
-            for stream in conn["syncCatalog"]["streams"]:
-                if stream["stream"]["name"].lower() == table_name:
-                    return conn["connectionId"]
-        return False
-
     def _get_source_id_by_name(self, source_name):
-        for source in self.airbyte_api.airbyte_sources_list:
+        for source in self.airbyte_api.sources_list:
             if source["name"] == source_name:
                 return source["sourceId"]
 
     def _get_destination_id_by_name(self, destination_name):
-        for destination in self.airbyte_api.airbyte_destinations_list:
+        for destination in self.airbyte_api.destinations_list:
             if destination["name"] == destination_name:
                 return destination["destinationId"]
 
-    def _get_connection_id_by_endpoints(self, source_id, destination_id):
-        for connection in self.airbyte_api.airbyte_connections_list:
+    def _get_connection_by_endpoints(self, source_id, destination_id):
+        for connection in self.airbyte_api.connections_list:
             if (
                 connection["sourceId"] == source_id
                 and connection["destinationId"] == destination_id
@@ -524,32 +461,36 @@ class LoadAirbyteTask(BaseLoadTask):
     def _connection_already_updated(self, extracted_connection, current_connection):
         extracted_copy = copy(extracted_connection)
         current_copy = copy(current_connection)
-        extracted_copy.pop("sourceName")
-        extracted_copy.pop("destinationName")
-        current_copy.pop("connectionId")
-        current_copy.pop("sourceId")
-        current_copy.pop("destinationId")
-        current_copy.pop("breakingChange")
+        extracted_copy.pop("sourceName", None)
+        extracted_copy.pop("destinationName", None)
+        for field in (
+            "connectionId",
+            "sourceId",
+            "destinationId",
+            "breakingChange",
+            "createdAt",
+            "updatedAt",
+        ):
+            current_copy.pop(field, None)
         return extracted_copy == current_copy
 
     def _create_or_update_connection(self, connection_json: dict):
         """
-        Identify source_id and destination_id by their names
-        Update or create connection
+        Identify source_id and destination_id by their names, then update or create.
         """
         source_name = connection_json["sourceName"]
         destination_name = connection_json["destinationName"]
-        connection_json.pop("sourceCatalogId", "")
+        connection_json.pop("sourceCatalogId", None)
         source_id = self._get_source_id_by_name(source_name)
         destination_id = self._get_destination_id_by_name(destination_name)
         if not source_id or not destination_id:
             console.print(
-                f"No existent source-destination pair found for {connection_json['name']}"
+                f"No existent source-destination pair found for connection "
+                f"({source_name} → {destination_name})"
             )
             return
-        connection = self._get_connection_id_by_endpoints(source_id, destination_id)
+        connection = self._get_connection_by_endpoints(source_id, destination_id)
         if connection:
-            # Connection update
             if self._connection_already_updated(connection_json, connection):
                 console.print(
                     f"Connection [green]{connection['name']}[/green] already up to date. Skipping"
@@ -561,7 +502,6 @@ class LoadAirbyteTask(BaseLoadTask):
                 conn_name = self._create_connection(connection_json, source_id, destination_id)
                 self._add_update_result("connections", conn_name)
         else:
-            # Connection creation
             conn_name = self._create_connection(connection_json, source_id, destination_id)
             self.loading_results["connections"]["created"].append(conn_name)
 
@@ -572,21 +512,26 @@ class LoadAirbyteTask(BaseLoadTask):
             self.loading_results[obj_type]["updated"].append(obj_name)
 
     def _connector_versions_mismatch(self, exported_json_data, object_type):
-        if object_type == "source":
-            object_definition = self._get_source_definition_by_name(
-                exported_json_data["sourceName"]
-            )
-        if object_type == "destination":
-            object_definition = self._get_destination_definition_by_name(
-                exported_json_data["destinationName"]
-            )
+        try:
+            if object_type == "source":
+                source_type = exported_json_data.get("sourceType", "")
+                object_definition = self._get_source_definition_by_type(source_type)
+            else:
+                destination_type = exported_json_data.get("destinationType", "")
+                object_definition = self._get_destination_definition_by_type(destination_type)
+        except AirbyteLoaderException:
+            return
 
-        if exported_json_data["connectorVersion"] != object_definition["dockerImageTag"]:
+        current_version = object_definition.get("dockerImageTag", "unknown")
+        saved_version = exported_json_data.get("connectorVersion", "unknown")
+        if saved_version != "unknown" and saved_version != current_version:
+            connector_name = object_definition.get("name", object_type)
+            obj_name = exported_json_data.get("name", "")
             console.print(
-                f"[red]WARNING:[/red] Current Airbyte [b]{object_definition['name']}[/b] "
-                f"{object_type} connector version [b]({object_definition['dockerImageTag']})"
-                f"[/b] doesn't match exported [b]{exported_json_data['name']}[/b] "
-                f"version ({exported_json_data['connectorVersion']}) being loaded"
+                f"[red]WARNING:[/red] Current Airbyte [b]{connector_name}[/b] "
+                f"{object_type} connector version [b]({current_version})[/b] "
+                f"doesn't match exported [b]{obj_name}[/b] "
+                f"version ({saved_version}) being loaded"
             )
 
     def get_config_value(self, key):

--- a/dbt_coves/tasks/load/airbyte.py
+++ b/dbt_coves/tasks/load/airbyte.py
@@ -42,7 +42,12 @@ class LoadAirbyteTask(BaseLoadTask):
         subparser.add_argument(
             "--host",
             type=str,
-            help="Airbyte's API host, i.e. 'http://airbyte-server:8000'",
+            help="Airbyte's API host, i.e. 'http://airbyte-server'",
+        )
+        subparser.add_argument(
+            "--port",
+            type=str,
+            help="Airbyte's API port, i.e. '8006'",
         )
         subparser.add_argument(
             "--api-key",
@@ -78,6 +83,7 @@ class LoadAirbyteTask(BaseLoadTask):
         }
         self.load_destination = self.get_config_value("path")
         self.airbyte_host = self.get_config_value("host")
+        self.airbyte_port = self.get_config_value("port")
         self.airbyte_api_key = self.get_config_value("api_key")
         self.secrets_path = self.get_config_value("secrets_path")
         self.secrets_manager = self.get_config_value("secrets_manager")
@@ -108,7 +114,11 @@ class LoadAirbyteTask(BaseLoadTask):
         self.destinations_load_destination = os.path.abspath(path / "destinations")
         self.sources_load_destination = os.path.abspath(path / "sources")
 
-        self.airbyte_api = AirbyteApiCaller(self.airbyte_host, api_key=self.airbyte_api_key or None)
+        self.airbyte_api = AirbyteApiCaller(
+            self.airbyte_host,
+            api_port=self.airbyte_port or None,
+            api_key=self.airbyte_api_key or None,
+        )
 
         console.print(f"Loading DBT Sources into Airbyte from {os.path.abspath(path)}\n")
 

--- a/dbt_coves/utils/api_caller.py
+++ b/dbt_coves/utils/api_caller.py
@@ -54,68 +54,125 @@ class FivetranApiCallerException(Exception):
 
 
 class AirbyteApiCaller:
-    def api_call(self, endpoint: str, body: Dict[str, str] = None, timeout=None):
-        """
-        Generic `api caller` for contacting Airbyte
-        """
-        response = requests.post(endpoint, json=body, timeout=timeout)
-        if response.status_code >= 200 and response.status_code < 300:
-            return json.loads(response.text) if response.text else None
-        else:
-            raise AirbyteApiCallerException(
-                f"Unexpected status code from airbyte in endpoint {endpoint}:"
-                f"{response.status_code}: {json.loads(response.text)['message']}"
-            )
+    """
+    API caller for Airbyte's public REST API (/api/public/v1).
+    Replaces the old internal config API (/api/v1) which used POST for all operations.
+    """
 
-    def __init__(self, api_host, api_port):
-        airbyte_host = api_host
-        airbyte_port = api_port
-        airbyte_api_root = "api/v1/"
-        airbyte_api_base_endpoint = f"{airbyte_host}:{airbyte_port}/{airbyte_api_root}"
-
-        self.api_endpoints = {
-            "GET_OBJECTS": airbyte_api_base_endpoint + "{obj}/get",
-            "LIST_OBJECTS": airbyte_api_base_endpoint + "{obj}/list",
-            "CREATE_OBJECT": airbyte_api_base_endpoint + "{obj}/create",
-            "UPDATE_OBJECT": airbyte_api_base_endpoint + "{obj}/update",
-            "DELETE_OBJECT": airbyte_api_base_endpoint + "{obj}/delete",
-            "TEST_UPDATE": airbyte_api_base_endpoint + "{obj}/check_connection_for_update",
-            "TEST_CONNECTION": airbyte_api_base_endpoint + "{obj}/check_connection",
+    def __init__(self, api_host, api_key=None):
+        self.base_url = f"{api_host.rstrip('/')}/api/public/v1"
+        self.headers = {
+            "accept": "application/json",
+            "content-type": "application/json",
         }
+        if api_key:
+            self.headers["authorization"] = f"Bearer {api_key}"
+
         try:
             console.print("Querying [i]Airbyte[/i] connections")
-            self.airbyte_workspace_id = self.api_call(
-                self.api_endpoints["LIST_OBJECTS"].format(obj="workspaces")
-            )["workspaces"][0]["workspaceId"]
-            self.standard_request_body = {"workspaceId": self.airbyte_workspace_id}
-            self.airbyte_connections_list = self.api_call(
-                self.api_endpoints["LIST_OBJECTS"].format(obj="connections"),
-                self.standard_request_body,
-            )["connections"]
-            self.airbyte_sources_list = self.api_call(
-                self.api_endpoints["LIST_OBJECTS"].format(obj="sources"), self.standard_request_body
-            )["sources"]
-            self.airbyte_destinations_list = self.api_call(
-                self.api_endpoints["LIST_OBJECTS"].format(obj="destinations"),
-                self.standard_request_body,
-            )["destinations"]
-
+            workspaces = self._get_all("workspaces")
+            if not workspaces:
+                raise AirbyteApiCallerException("No Airbyte workspaces found")
+            self.workspace_id = workspaces[0]["workspaceId"]
+            self.connections_list = self._get_all("connections", workspaceIds=self.workspace_id)
+            self.sources_list = self._get_all("sources", workspaceIds=self.workspace_id)
+            self.destinations_list = self._get_all("destinations", workspaceIds=self.workspace_id)
             self.load_definitions()
         except AirbyteApiCallerException as e:
             raise AirbyteApiCallerException(
-                f"Couldn't retrieve Airbyte connections, sources and destinations {e}"
+                f"Couldn't retrieve Airbyte connections, sources and destinations: {e}"
             )
 
-    def load_definitions(self):
-        self.destination_definitions = self.api_call(
-            self.api_endpoints["LIST_OBJECTS"].format(obj="destination_definitions"),
-            self.standard_request_body,
-        )["destinationDefinitions"]
+    def _request(self, method, path, body=None, params=None, timeout=None):
+        url = f"{self.base_url}/{path.lstrip('/')}"
+        response = requests.request(
+            method, url=url, json=body, params=params, headers=self.headers, timeout=timeout
+        )
+        if response.status_code == 204:
+            return None
+        if 200 <= response.status_code < 300:
+            return response.json() if response.text else None
+        try:
+            message = response.json().get("message", response.text)
+        except Exception:
+            message = response.text
+        raise AirbyteApiCallerException(
+            f"Airbyte API error ({response.status_code}) at {path}: {message}"
+        )
 
-        self.source_definitions = self.api_call(
-            self.api_endpoints["LIST_OBJECTS"].format(obj="source_definitions"),
-            self.standard_request_body,
-        )["sourceDefinitions"]
+    def _get_all(self, resource, **params):
+        """Fetch all pages from a list endpoint, handling pagination."""
+        results = []
+        limit = 100
+        offset = 0
+        while True:
+            page = self._request(
+                "GET", resource, params={"limit": limit, "offset": offset, **params}
+            )
+            data = page.get("data", [])
+            results.extend(data)
+            if len(data) < limit:
+                break
+            offset += limit
+        return results
+
+    def load_definitions(self):
+        self.destination_definitions = self._get_all(
+            "connector_definitions/destinations", workspaceId=self.workspace_id
+        )
+        self.source_definitions = self._get_all(
+            "connector_definitions/sources", workspaceId=self.workspace_id
+        )
+
+    def get_source_spec(self, definition_id):
+        """Fetch connector spec (including airbyte_secret markers) for a source definition."""
+        try:
+            return self._request("GET", f"connector_definitions/sources/{definition_id}")
+        except AirbyteApiCallerException:
+            return None
+
+    def get_destination_spec(self, definition_id):
+        """Fetch connector spec for a destination definition."""
+        try:
+            return self._request("GET", f"connector_definitions/destinations/{definition_id}")
+        except AirbyteApiCallerException:
+            return None
+
+    # Source CRUD
+    def create_source(self, body):
+        return self._request("POST", "sources", body=body)
+
+    def update_source(self, source_id, body):
+        return self._request("PATCH", f"sources/{source_id}", body=body)
+
+    def delete_source(self, source_id):
+        self._request("DELETE", f"sources/{source_id}")
+
+    def check_source(self, source_id, timeout=None):
+        return self._request("POST", f"sources/{source_id}/check", timeout=timeout)
+
+    # Destination CRUD
+    def create_destination(self, body):
+        return self._request("POST", "destinations", body=body)
+
+    def update_destination(self, destination_id, body):
+        return self._request("PATCH", f"destinations/{destination_id}", body=body)
+
+    def delete_destination(self, destination_id):
+        self._request("DELETE", f"destinations/{destination_id}")
+
+    def check_destination(self, destination_id, timeout=None):
+        return self._request("POST", f"destinations/{destination_id}/check", timeout=timeout)
+
+    # Connection CRUD
+    def create_connection(self, body):
+        return self._request("POST", "connections", body=body)
+
+    def update_connection(self, connection_id, body):
+        return self._request("PATCH", f"connections/{connection_id}", body=body)
+
+    def delete_connection(self, connection_id):
+        self._request("DELETE", f"connections/{connection_id}")
 
 
 class FivetranApiCaller:

--- a/dbt_coves/utils/api_caller.py
+++ b/dbt_coves/utils/api_caller.py
@@ -59,8 +59,11 @@ class AirbyteApiCaller:
     Replaces the old internal config API (/api/v1) which used POST for all operations.
     """
 
-    def __init__(self, api_host, api_key=None):
-        self.base_url = f"{api_host.rstrip('/')}/api/public/v1"
+    def __init__(self, api_host, api_port=None, api_key=None):
+        host = api_host.rstrip("/")
+        if api_port:
+            host = f"{host}:{api_port}"
+        self.base_url = f"{host}/api/public/v1"
         self.headers = {
             "accept": "application/json",
             "content-type": "application/json",

--- a/dbt_coves/utils/api_caller.py
+++ b/dbt_coves/utils/api_caller.py
@@ -80,11 +80,11 @@ class AirbyteApiCaller:
             self.connections_list = self._get_all("connections", workspaceIds=self.workspace_id)
             self.sources_list = self._get_all("sources", workspaceIds=self.workspace_id)
             self.destinations_list = self._get_all("destinations", workspaceIds=self.workspace_id)
-            self.load_definitions()
         except AirbyteApiCallerException as e:
             raise AirbyteApiCallerException(
                 f"Couldn't retrieve Airbyte connections, sources and destinations: {e}"
             )
+        self.load_definitions()
 
     def _request(self, method, path, body=None, params=None, timeout=None):
         url = f"{self.base_url}/{path.lstrip('/')}"
@@ -120,12 +120,24 @@ class AirbyteApiCaller:
         return results
 
     def load_definitions(self):
-        self.destination_definitions = self._get_all(
-            "connector_definitions/destinations", workspaceId=self.workspace_id
-        )
-        self.source_definitions = self._get_all(
-            "connector_definitions/sources", workspaceId=self.workspace_id
-        )
+        """
+        Fetch connector definitions (used for version checking and secret field discovery).
+        Non-fatal: some Airbyte versions don't expose this endpoint in the public API.
+        """
+        self.source_definitions = []
+        self.destination_definitions = []
+        try:
+            self.source_definitions = self._get_all(
+                "connector_definitions/sources", workspaceId=self.workspace_id
+            )
+            self.destination_definitions = self._get_all(
+                "connector_definitions/destinations", workspaceId=self.workspace_id
+            )
+        except AirbyteApiCallerException as e:
+            console.print(
+                f"[yellow]Warning:[/yellow] Could not load connector definitions ({e}). "
+                "Connector version checking and secret masking will be skipped."
+            )
 
     def get_source_spec(self, definition_id):
         """Fetch connector spec (including airbyte_secret markers) for a source definition."""

--- a/dbt_coves/utils/api_caller.py
+++ b/dbt_coves/utils/api_caller.py
@@ -96,7 +96,10 @@ class AirbyteApiCaller:
         if 200 <= response.status_code < 300:
             return response.json() if response.text else None
         try:
-            message = response.json().get("message", response.text)
+            error_body = response.json()
+            message = error_body.get("message", "") or error_body.get("detail", "")
+            if not message:
+                message = json.dumps(error_body)
         except Exception:
             message = response.text
         raise AirbyteApiCallerException(

--- a/dbt_coves/utils/api_caller.py
+++ b/dbt_coves/utils/api_caller.py
@@ -136,11 +136,13 @@ class AirbyteApiCaller:
             self.destination_definitions = self._get_all(
                 "connector_definitions/destinations", workspaceId=self.workspace_id
             )
-        except AirbyteApiCallerException as e:
-            console.print(
-                f"[yellow]Warning:[/yellow] Could not load connector definitions ({e}). "
-                "Connector version checking and secret masking will be skipped."
-            )
+        except AirbyteApiCallerException:
+            # Silently don't worry about it for now.
+            pass
+            # console.print(
+            #     f"[yellow]Warning:[/yellow] Could not load connector definitions ({e}). "
+            #     "Connector version checking and secret masking will be skipped."
+            # )
 
     def get_source_spec(self, definition_id):
         """Fetch connector spec (including airbyte_secret markers) for a source definition."""

--- a/docs/2 - Commands/extract/airbyte/README.md
+++ b/docs/2 - Commands/extract/airbyte/README.md
@@ -25,8 +25,13 @@ dbt-coves extract airbyte <arguments>
 # Airbyte's API port, i.e. '8001'
 ```
 
+```shell
+--api-key
+# Airbyte's API key (required for Airbyte Cloud and modern self-hosted instances)
+```
+
 ### Sample usage
 
 ```shell
-dbt-coves extract airbyte --host http://airbyte-server --port 8001 --path /config/workspace/load/airbyte
+dbt-coves extract airbyte --host http://airbyte-server --port 8001 --api-key <your-api-key> --path /config/workspace/load/airbyte
 ```

--- a/docs/commands/extract and load/airbyte/README.md
+++ b/docs/commands/extract and load/airbyte/README.md
@@ -9,7 +9,7 @@ Extracts the configuration from your Airbyte sources, connections and destinatio
 Full usage example:
 
 ```console
-dbt-coves extract airbyte --host http://airbyte-server --port 8001 --path /config/workspace/load/airbyte
+dbt-coves extract airbyte --host http://airbyte-server --port 8001 --api-key <your-api-key> --path /config/workspace/load/airbyte
 ```
 
 ## Load configuration to Airbyte
@@ -50,5 +50,5 @@ To load encrypted fields through a manager (in this case we are connecting to Da
 Full usage example:
 
 ```console
-dbt-coves load airbyte --host http://airbyte-server --port 8001 --path /config/workspace/load/airbyte --secrets-path /config/workspace/secrets
+dbt-coves load airbyte --host http://airbyte-server --port 8001 --api-key <your-api-key> --path /config/workspace/load/airbyte --secrets-path /config/workspace/secrets
 ```

--- a/docs/commands/generate/airflow dags/README.md
+++ b/docs/commands/generate/airflow dags/README.md
@@ -27,7 +27,7 @@ Generators are custom classes that receive YML `key:value` pairs and return one 
 We provide some prebuilt Generators:
 
 - `AirbyteGenerator` creates `AirbyteTriggerSyncOperator` tasks (one per Airbyte connection)
-  - It must receive Airbyte's `host` and `port`, `airbyte_conn_id` (Airbyte's connection name on Airflow) and a `connection_ids` list of Airbyte Connections to Sync
+  - It must receive Airbyte's `host`, `airbyte_conn_id` (Airbyte's connection name on Airflow) and a `connection_ids` list of Airbyte Connections to Sync. `port` and `api_key` are optional (API key required for Airbyte Cloud and modern self-hosted instances)
 - `FivetranGenerator`: creates `FivetranOperator` tasks (one per Fivetran connection)
   - It must receive Fivetran's `api_key`, `api_secret` and a `connection_ids` list of Fivetran Connectors to Sync.
 - `AirbyteDbtGenerator` and `FivetranDbtGenerator`: instead of passing them Airbyte or Fivetran connections, they use dbt to discover those IDs. Apart from their parent Generators mandatory fields, they can receive:
@@ -53,6 +53,7 @@ nodes:
     generator: AirbyteDbtGenerator
     host: http://localhost
     port: 8000
+    api_key: "{{ env_var('AIRBYTE_API_KEY') }}"
     dbt_project_path: /path/to/dbt_project
     virtualenv_path: /virtualenvs/dbt_160
     run_dbt_compile: false
@@ -104,7 +105,7 @@ class PostgresGenerator():
 
 --generators-params
 # Object with default values for the desired Generator(s)
-# For example: {"AirbyteGenerator": {"host": "http://localhost", "port": "8000"}}
+# For example: {"AirbyteGenerator": {"host": "http://localhost", "port": "8000", "api_key": "<your-api-key>"}}
 
 --secrets-path
 # Secret files location for DAG configuration, i.e. 'yml_path/secrets/'

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -56,6 +56,7 @@ generate:
       AirbyteDbtGenerator:
         host: "{{ env_var('AIRBYTE_HOST_NAME') }}"
         port: "{{ env_var('AIRBYTE_PORT') }}"
+        api_key: "{{ env_var('AIRBYTE_API_KEY') }}"
         airbyte_conn_id: airbyte_connection
 
         dbt_project_path: "{{ env_var('DBT_HOME') }}"
@@ -66,7 +67,8 @@ extract:
   airbyte:
     path: /config/workspace/load/airbyte # Where json files will be generated
     host: http://airbyte-server # Airbyte's API hostname
-    port: 8001 # Airbyte's API port
+    port: 8001 # Airbyte's API port (optional)
+    api_key: [API_KEY] # Airbyte's API key (required for Airbyte Cloud and modern self-hosted instances)
   fivetran:
     path: /config/workspace/load/fivetran # Where Fivetran export will be generated
     api_key: [KEY] # Fivetran API Key
@@ -78,7 +80,8 @@ load:
   airbyte:
     path: /config/workspace/load
     host: http://airbyte-server
-    port: 8001
+    port: 8001 # optional
+    api_key: [API_KEY] # Airbyte's API key (required for Airbyte Cloud and modern self-hosted instances)
     secrets_manager: datacoves # (optional) Secret credentials provider (secrets_path OR secrets_manager should be used, can't load secrets locally and remotely at the same time)
     secrets_path: /config/workspace/secrets # (optional) Secret files location if secrets_manager was not specified
     secrets_url: https://api.datacoves.localhost/service-credentials/airbyte # Secrets url if secrets_manager is datacoves


### PR DESCRIPTION
This is a fairly comprehensive update to add support for Airbyte's public REST API for such things as `generate airflow-dags` and `extract`; the previous internal API is obsolete.