### PR TITLE
[Dcv-3873] Improve dbt-coves generate airflow dags output

### DIFF
--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -39,6 +39,10 @@ class GenerateAirflowDagsException(Exception):
     pass
 
 
+class RawExpr(str):
+    """A string marked via the `!py` YAML tag to be emitted as a raw, unquoted Python expression."""
+
+
 class GenerateAirflowDagsTask(NonDbtBaseTask):
     """
     Task that generate sources, models and model properties automatically
@@ -110,11 +114,16 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         value = loader.construct_scalar(node)
         return datetime.datetime.strptime(value, "%Y-%m-%d")
 
+    # Custom constructor for `!py` tagged values: emitted as raw Python expressions
+    def raw_expr_constructor(self, loader, node):
+        return RawExpr(loader.construct_scalar(node))
+
     def get_config_value(self, key):
         return self.coves_config.integrated["generate"]["airflow_dags"][key]
 
     def _generate_dag(self, yml_filepath: Path):
         yaml.FullLoader.add_constructor("tag:yaml.org,2002:timestamp", self.date_constructor)
+        yaml.FullLoader.add_constructor("!py", self.raw_expr_constructor)
         console.print(f"Generating [b][i]{yml_filepath.stem}[/i][/b]")
         try:
             if self.dags_path:
@@ -175,11 +184,14 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
                 for call in self.generate_notifiers(yaml["notifications"]):
                     dag_args += f"{indent * ' '}{call},\n"
             else:
-                dag_value = (
-                    f'"{value}"' if (isinstance(value, str) and "config" not in key) else value
-                )
+                if isinstance(value, RawExpr):
+                    dag_value = str(value)
+                elif isinstance(value, str) and "config" not in key:
+                    dag_value = f'"{value}"'
+                else:
+                    dag_value = value
                 dag_args += f'{indent * " "}{key}={dag_value},\n'
-        return dag_args[:-2]
+        return dag_args[:-1]
 
     def generate_notifiers(self, notifiers: Dict[str, Any]):
         """
@@ -208,7 +220,7 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
             if isinstance(callback_args, list):
                 for arg in callback_args:
                     if isinstance(arg, dict):
-                        arg = self.dag_args_to_string(arg, indent=4)
+                        arg = self.dag_args_to_string(arg, indent=4).rstrip(",")
                         usage_args.append(arg)
                     if isinstance(arg, int):
                         usage_args.append(f"{arg}")
@@ -230,17 +242,24 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
                 f"YML file [red][b][i]{dag_name}[/i][/b][/red] must contain a 'nodes' section"
             )
         default_args = {"default_args": yml_dag.pop("default_args", {})}
+        extra_imports = yml_dag.pop("imports", [])
+        doc_md = yml_dag.pop("doc_md", None)
         self.dag_output = {
+            "docstring": [],
             "imports": [
                 "from airflow.decorators import dag\n",
                 "import datetime\n",
+                *[f"{imp}\n" for imp in extra_imports],
             ],
             "globals": [],
             "dag": [
                 "@dag(\n",
-                f"{self.dag_args_to_string(default_args)},\n",
+                f"{self.dag_args_to_string(default_args)}\n",
             ],
         }
+        if doc_md:
+            self.dag_output["docstring"].append(f'"""\n{doc_md.rstrip()}\n"""\n\n')
+            yml_dag["doc_md"] = RawExpr("__doc__")
         self.dag_output["dag"].extend(
             [
                 f"{self.dag_args_to_string(yml_dag)}\n",
@@ -256,7 +275,8 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
 
         with open(destination_path, "w") as f:
             final_output = (
-                "".join(set(self.dag_output["imports"]))
+                "".join(self.dag_output["docstring"])
+                + "".join(set(self.dag_output["imports"]))
                 + "".join(self.dag_output["globals"])
                 + "".join(self.dag_output["dag"])
             )
@@ -336,8 +356,9 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         Generate Task Groups, using YML's `generator` or `tasks`
         """
         self.dag_output["imports"].append("from airflow.decorators import task_group\n"),
+        tg_tooltip = tg_conf.pop("tooltip", "")
         task_group_output = [
-            f"{' ' * 4}@task_group(group_id='{tg_name}', tooltip='{tg_conf.pop('tooltip', '')}')\n",
+            f"{' ' * 4}@task_group(group_id='{tg_name}', tooltip='{tg_tooltip}',)\n",
             f"{' ' * 4}def {tg_name}():\n",
         ]
         generator = tg_conf.pop("generator", "")
@@ -459,7 +480,7 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
             # Render decorated function
             task_output = [
                 f"{' ' * indent}@task.{task_decorator}(\n",
-                f"{' ' * (indent + 4)}{', '.join(decorator_args)}\n",
+                f"{' ' * (indent + 4)}{', '.join(decorator_args)},\n",
                 f"{' ' * indent})\n",
                 f"{' ' * indent}def {task_name}():\n",
                 f"{' ' * (indent + 4)}return \"{bash_command}\"\n",

--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -160,8 +160,6 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         self.secrets_manager = self.get_config_value("secrets_manager")
         self.yml_dags_path_env = os.environ.get("DATACOVES__AIRFLOW_DAGS_YML_PATH")
 
-        self.generated_groups = {}
-        self.collected_dependencies = []
         if self.secrets_path and self.secrets_manager:
             raise GenerateAirflowDagsException(
                 "Can't use 'secrets_path' and 'secrets_manager' simultaneously."
@@ -234,6 +232,8 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         """
         Generate DAG Python file based on YML configuration
         """
+        self.generated_groups = {}
+        self.collected_dependencies = []
         yml_dag = self._discover_secrets(yml_dag)
         try:
             nodes = yml_dag.pop("nodes")

--- a/docs/commands/generate/airflow dags/README.md
+++ b/docs/commands/generate/airflow dags/README.md
@@ -8,33 +8,19 @@ Translate YML files into their Airflow Python code equivalent. With this, DAGs c
 
 The basic structure of these YMLs must consist of:
 
-- Global configurations (description, schedule_interval, tags, catchup, etc.)
+- Global configurations (`description`, `schedule`/`schedule_interval`, `tags`, `catchup`, etc.) — any `key:value` pair here is passed straight through as an argument to Airflow's `@dag(...)` decorator.
+- `imports`: extra Python import statements the generated file needs (optional)
+- `doc_md`: a Markdown string used as the DAG's module docstring and `doc_md` (optional)
+- `notifications`: `on_success_callback` / `on_failure_callback` (or any other `@dag()` callback argument) built from a notifier class (optional)
 - `default_args`
 - `nodes`: where tasks and task groups are defined
   - each Node is a nested object, with it's `name` as key and it's configuration as values.
     - this configuration must cover:
       - `type`: 'task' or 'task_group'
-      - `operator`: Airflow operator that will run the tasks (full _module.class_ naming)
+      - `operator`: Airflow operator that will run the task (full _module.class_ naming), **or**
+      - `task_decorator`: the name of a `@task.<decorator>` TaskFlow decorator to use instead of an `operator` (e.g. Datacoves' `datacoves_dbt`)
       - `dependencies`: whether the task is dependent on another one(s)
-      - any `key:value` pair of [Operator arguments](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/operators/index.html)
-
-### Airflow DAG Generators
-
-When a YML Dag `node` is of type `task_group`, **Generators** can be used instead of `Operators`.
-
-Generators are custom classes that receive YML `key:value` pairs and return one or more tasks for the respective task group. Any pair specified other than `type: task_group` will be passed to the specified `generator`, and it has the responsibility of returning N amount of `task_name = Operator(params)`.
-
-We provide some prebuilt Generators:
-
-- `AirbyteGenerator` creates `AirbyteTriggerSyncOperator` tasks (one per Airbyte connection)
-  - It must receive Airbyte's `host`, `airbyte_conn_id` (Airbyte's connection name on Airflow) and a `connection_ids` list of Airbyte Connections to Sync. `port` and `api_key` are optional (API key required for Airbyte Cloud and modern self-hosted instances)
-- `FivetranGenerator`: creates `FivetranOperator` tasks (one per Fivetran connection)
-  - It must receive Fivetran's `api_key`, `api_secret` and a `connection_ids` list of Fivetran Connectors to Sync.
-- `AirbyteDbtGenerator` and `FivetranDbtGenerator`: instead of passing them Airbyte or Fivetran connections, they use dbt to discover those IDs. Apart from their parent Generators mandatory fields, they can receive:
-  - `dbt_project_path`: dbt/project/folder
-  - `virtualenv_path`: path to a virtualenv in case dbt within a specific virtual env
-  - `run_dbt_compile`: true/false always run the dbt compile command
-  - `run_dbt_deps`: true/false always run the dbt deps command
+      - any `key:value` pair of [Operator arguments](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/operators/index.html) (or decorator arguments, when using `task_decorator`)
 
 ### Basic YML DAG example:
 
@@ -65,6 +51,169 @@ nodes:
     dependencies: ["airbyte_dbt"]
 ```
 
+### Custom imports
+
+Use the top-level `imports` key to add any extra import statements the generated DAG needs (for example, to call a helper module from a raw Python expression, see below). Each entry is written verbatim as its own import line; `isort` runs on the generated file, so ordering and de-duplication are handled automatically.
+
+```yaml
+imports:
+  - "from orchestrate.utils import datacoves_utils"
+```
+
+### DAG docstring (`doc_md`)
+
+A `doc_md` block becomes the file's module docstring (rendered by Airflow's UI as the DAG's documentation) and is automatically wired into the `@dag()` call as `doc_md=__doc__`.
+
+```yaml
+doc_md: |
+  ## Sample DAG showing how to run dbt
+  This DAG shows how to run a dbt task
+```
+
+### Raw Python expressions with `!py`
+
+Every YML value is rendered into the generated Python as a literal: strings are quoted, numbers/booleans/lists are dumped as-is. Tag a string with `!py` when you need it emitted as an **unquoted Python expression** instead — for example, to call a helper function like Datacoves' `datacoves_utils.set_schedule(...)` or `datacoves_utils.set_default_args(...)`:
+
+```yaml
+schedule: !py datacoves_utils.set_schedule("0 0 1 */12 *")
+default_args: !py datacoves_utils.set_default_args(owner="Noel Gomez", owner_email="noel@example.com")
+```
+
+`!py` can be used anywhere a `key: value` pair is rendered — at the DAG level, inside `default_args`, or as a task/decorator argument. Remember to add the corresponding `imports` entry for any module referenced in the expression.
+
+Putting it all together, this YAML:
+
+```yaml
+imports:
+  - "from orchestrate.utils import datacoves_utils"
+doc_md: |
+  ## Sample DAG showing how to run dbt
+  This DAG shows how to run a dbt task
+schedule: !py datacoves_utils.set_schedule("0 0 1 */12 *")
+default_args: !py datacoves_utils.set_default_args(owner="Noel Gomez", owner_email="noel@example.com")
+description: "Sample DAG demonstrating how to run dbt in airflow"
+tags:
+  - transform
+catchup: false
+nodes:
+  run_dbt:
+    type: task
+    task_decorator: datacoves_dbt
+    connection_id: main_key_pair
+    bash_command: "dbt debug"
+```
+
+generates:
+
+```python
+"""
+## Sample DAG showing how to run dbt
+This DAG shows how to run a dbt task
+"""
+
+import datetime
+
+from airflow.decorators import dag, task
+from orchestrate.utils import datacoves_utils
+
+
+@dag(
+    default_args=datacoves_utils.set_default_args(
+        owner="Noel Gomez", owner_email="noel@example.com"
+    ),
+    schedule=datacoves_utils.set_schedule("0 0 1 */12 *"),
+    description="Sample DAG demonstrating how to run dbt in airflow",
+    tags=["transform"],
+    catchup=False,
+    doc_md=__doc__,
+)
+def dbt_dag():
+    @task.datacoves_dbt(
+        connection_id="main_key_pair",
+    )
+    def run_dbt():
+        return "dbt debug"
+
+    run_dbt = run_dbt()
+
+
+dag = dbt_dag()
+```
+
+### Tasks via `operator` vs `task_decorator`
+
+Most tasks are written with a classic `operator`, which is instantiated directly:
+
+```yaml
+nodes:
+  transform:
+    type: task
+    operator: airflow.operators.bash.BashOperator
+    bash_command: "dbt run"
+```
+
+Alternatively, use `task_decorator` to generate an Airflow [TaskFlow](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/taskflow.html)-style `@task.<decorator>` function instead. This is how Datacoves' custom `datacoves_dbt` (and similar) task decorators are used:
+
+```yaml
+nodes:
+  run_dbt:
+    type: task
+    task_decorator: datacoves_dbt
+    connection_id: main_key_pair
+    bash_command: "dbt debug"
+```
+
+Any remaining `key: value` pairs (besides `bash_command` and `dependencies`) become arguments to the decorator itself, e.g. `@task.datacoves_dbt(connection_id="main_key_pair")`.
+
+### Kubernetes executor config
+
+Add a `config` block to a task to generate a `KubernetesExecutor` pod override (`executor_config=...`), including a dedicated `from kubernetes.client import models as k8s` import and a `<TASK_NAME>_CONFIG` global:
+
+```yaml
+nodes:
+  transform:
+    type: task
+    operator: airflow.operators.bash.BashOperator
+    bash_command: "dbt run"
+    config:
+      image: datacoves/airflow-pandas:latest
+      resources:
+        memory: 8Gi
+        cpu: 1000m
+```
+
+### Notifications / callbacks
+
+Use the top-level `notifications` key to wire up `on_success_callback` / `on_failure_callback` (or any other `@dag()` callback argument) to a notifier class, without having to hand-write the import and instantiation:
+
+```yaml
+notifications:
+  on_failure_callback:
+    notifier: dbt_coves.notifications.slack.SlackNotifier # or `callback`
+    args:
+      webhook_url: "{{ env_var('SLACK_WEBHOOK_URL') }}"
+```
+
+`notifier` (or its alias `callback`) must be the full _module.class_ path of the notifier/callback to import and call; `args` is passed to it as `key=value` arguments (or positional values, when given as a list).
+
+### Airflow DAG Generators
+
+When a YML Dag `node` is of type `task_group`, **Generators** can be used instead of `Operators`.
+
+Generators are custom classes that receive YML `key:value` pairs and return one or more tasks for the respective task group. Any pair specified other than `type: task_group` will be passed to the specified `generator`, and it has the responsibility of returning N amount of `task_name = Operator(params)`.
+
+We provide some prebuilt Generators:
+
+- `AirbyteGenerator` creates `AirbyteTriggerSyncOperator` tasks (one per Airbyte connection)
+  - It must receive Airbyte's `host`, `airbyte_conn_id` (Airbyte's connection name on Airflow) and a `connection_ids` list of Airbyte Connections to Sync. `port` and `api_key` are optional (API key required for Airbyte Cloud and modern self-hosted instances)
+- `FivetranGenerator`: creates `FivetranOperator` tasks (one per Fivetran connection)
+  - It must receive Fivetran's `api_key`, `api_secret` and a `connection_ids` list of Fivetran Connectors to Sync.
+- `AirbyteDbtGenerator` and `FivetranDbtGenerator`: instead of passing them Airbyte or Fivetran connections, they use dbt to discover those IDs. Apart from their parent Generators mandatory fields, they can receive:
+  - `dbt_project_path`: dbt/project/folder
+  - `virtualenv_path`: path to a virtualenv in case dbt within a specific virtual env
+  - `run_dbt_compile`: true/false always run the dbt compile command
+  - `run_dbt_deps`: true/false always run the dbt deps command
+
 ### Create your custom Generator
 
 You can create your own DAG Generator. Any `key:value` specified in the YML DAG will be passed to it's constructor.
@@ -84,6 +233,15 @@ class PostgresGenerator():
         """ Use your custom logic and return N `name = PostgresOperator()` strings """
         raise NotImplementedError
 ```
+
+### Secrets
+
+Sensitive values (API keys, connection credentials, etc.) don't need to be hardcoded in the YML DAGs. Two mechanisms are supported, and they merge into the `nodes` section of the YML DAG before it's translated to Python:
+
+- **Local secret files** (`--secrets-path`): YML files placed in a folder, each with the same `nodes -> node_name -> ...` shape as the DAG YML, deep-merged into it.
+- **Secrets manager** (`--secrets-manager`): currently supports `datacoves`. Requires `--secrets-url`, `--secrets-token` and `--secrets-environment` (or the `DATACOVES__SECRETS_URL`, `DATACOVES__SECRETS_TOKEN` and `DATACOVES__ENVIRONMENT_SLUG` env vars). Optionally filter the secrets fetched with `--secrets-tags` and/or `--secrets-key`. Reference a fetched secret anywhere in the YML DAG with `{{ secret('secret_slug') }}`.
+
+`--secrets-path` and `--secrets-manager` are mutually exclusive.
 
 ### Arguments
 
@@ -110,4 +268,23 @@ class PostgresGenerator():
 --secrets-path
 # Secret files location for DAG configuration, i.e. 'yml_path/secrets/'
 # Secret content must match the YML dag spec of `nodes -> node_name -> config`
+
+--secrets-manager
+# Secret credentials provider, i.e. 'datacoves'
+# Mutually exclusive with --secrets-path
+
+--secrets-url
+# Secret credentials provider url
+
+--secrets-token
+# Secret credentials provider token
+
+--secrets-environment
+# Secret credentials project/environment slug
+
+--secrets-tags
+# Comma-separated tags to filter which secrets are fetched from the secrets manager
+
+--secrets-key
+# Fetch a single secret by key from the secrets manager
 ```


### PR DESCRIPTION
Three improvements to the Airflow DAG generator:
- Multiple tasks no longer leak into one another.
- Generates more flexible and more idiomatic DAGs per the feature requests.  This includes custom imports, a file level docstring, passing raw Python expressions as arguments, and better rendering of arguments.
- Updated documentation covering all features.

Fixes #564, #566, #583.