### PR TITLE
Improve startup time

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -31,6 +31,7 @@ jobs:
         run: uv sync --group test
 
       - name: Load secrets
+        if: github.actor != 'dependabot[bot]'
         uses: 1password/load-secrets-action@v1
         with:
           # Export loaded secrets as environment variables
@@ -69,15 +70,18 @@ jobs:
           SNOWFLAKE_PRIVATE_KEY: op://Engineering - dbt-coves/dbt-coves-tests/SNOWFLAKE_PRIVATE_KEY
 
       - name: Create profiles
+        if: github.actor != 'dependabot[bot]'
         run: |
           uv run python tests/create_profiles.py
           mkdir $HOME/.dbt
           mv tests/profiles.yml $HOME/.dbt/profiles.yml
 
       - name: Run Tests and Coverage Report
+        if: github.actor != 'dependabot[bot]'
         run: uv run tox
 
       - name: Upload coverage report to CodeCov
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v2
         with:
           env_vars: GITHUB_RUN_ID

--- a/dbt_coves/__init__.py
+++ b/dbt_coves/__init__.py
@@ -1,6 +1,14 @@
-import dbt.version
-
 __version__ = "1.11.2"
-__dbt_major_version__ = int(dbt.version.installed.major or 0)
-__dbt_minor_version__ = int(dbt.version.installed.minor or 0)
-__dbt_patch_version__ = int(dbt.version.installed.patch or 0)
+
+
+def __getattr__(name: str):
+    if name in ("__dbt_major_version__", "__dbt_minor_version__", "__dbt_patch_version__"):
+        import dbt.version
+
+        v = dbt.version.installed
+        global __dbt_major_version__, __dbt_minor_version__, __dbt_patch_version__
+        __dbt_major_version__ = int(v.major or 0)
+        __dbt_minor_version__ = int(v.minor or 0)
+        __dbt_patch_version__ = int(v.patch or 0)
+        return globals()[name]
+    raise AttributeError(f"module 'dbt_coves' has no attribute {name!r}")

--- a/dbt_coves/core/main.py
+++ b/dbt_coves/core/main.py
@@ -1,4 +1,5 @@
 import argparse
+import importlib
 import os
 import pathlib
 import sys
@@ -14,27 +15,65 @@ from dbt_coves import __version__
 from dbt_coves.config.config import DbtCovesConfig
 from dbt_coves.core.exceptions import MissingCommand, MissingDbtProject
 from dbt_coves.tasks.base import BaseTask
-from dbt_coves.tasks.blue_green.main import BlueGreenTask
-from dbt_coves.tasks.data_sync.main import DataSyncTask
-from dbt_coves.tasks.dbt.main import RunDbtTask
-from dbt_coves.tasks.extract.main import ExtractTask
-from dbt_coves.tasks.generate.main import GenerateTask
-from dbt_coves.tasks.load.main import LoadTask
-from dbt_coves.tasks.setup.main import SetupTask
 from dbt_coves.ui.traceback import DbtCovesTraceback
 from dbt_coves.utils.flags import DbtCovesFlags
 from dbt_coves.utils.log import LOGGER as logger
 from dbt_coves.utils.log import log_manager
 from dbt_coves.utils.yaml import open_yaml, save_yaml
 
+# Registry: subcommand name → (module path, class name, help text)
+_TASK_REGISTRY = {
+    "generate": (
+        "dbt_coves.tasks.generate.main",
+        "GenerateTask",
+        "Generates dbt source and staging files, model property files and extracts\n"
+        "                     metadata for tables (used as input for sources and properties)",
+    ),
+    "setup": (
+        "dbt_coves.tasks.setup.main",
+        "SetupTask",
+        "Set up dbt project components (dbt project, CI, pre-commit, Airflow DAGs)",
+    ),
+    "extract": (
+        "dbt_coves.tasks.extract.main",
+        "ExtractTask",
+        "Extract configuration data from Airbyte or Fivetran",
+    ),
+    "load": (
+        "dbt_coves.tasks.load.main",
+        "LoadTask",
+        "Loads configurations into different systems, such as Airbyte.",
+    ),
+    "dbt": (
+        "dbt_coves.tasks.dbt.main",
+        "RunDbtTask",
+        "Use this command to run dbt commands on special environments\n"
+        "                    such as Airflow, or CI workers. When a read-write copy needs to be\n"
+        "                    created, its path can be found in /tmp/dbt_coves_dbt_clone_path.txt.",
+    ),
+    "data-sync": (
+        "dbt_coves.tasks.data_sync.main",
+        "DataSyncTask",
+        "Upload Airflow tables to Snowflake or Redshift",
+    ),
+    "blue-green": (
+        "dbt_coves.tasks.blue_green.main",
+        "BlueGreenTask",
+        "Command to perform blue-green dbt runs",
+    ),
+}
+
 try:
     from dbt.flags import PROFILES_DIR
 
     VARS_DEFAULT_IS_STR = False
 except ImportError:
-    from dbt.cli.resolvers import default_profiles_dir
-
-    PROFILES_DIR = os.environ.get("DBT_PROFILES_DIR") or default_profiles_dir()
+    # dbt >= 1.8: replicate default_profiles_dir() inline to avoid importing dbt.cli.main
+    _cwd = pathlib.Path.cwd()
+    PROFILES_DIR = str(
+        os.environ.get("DBT_PROFILES_DIR")
+        or (_cwd if (_cwd / "profiles.yml").exists() else pathlib.Path.home() / ".dbt")
+    )
     VARS_DEFAULT_IS_STR = True
 
 console = Console()
@@ -226,19 +265,32 @@ base_subparser.add_argument(
 
 sub_parsers = parser.add_subparsers(title="dbt-coves commands", dest="task")
 
-# Register subcommands
-[
-    task.register_parser(sub_parsers, base_subparser)
-    for task in [
-        GenerateTask,
-        SetupTask,
-        ExtractTask,
-        LoadTask,
-        RunDbtTask,
-        DataSyncTask,
-        BlueGreenTask,
-    ]
-]
+
+def _detect_subcommand() -> str | None:
+    """Return the first argv token that matches a known subcommand, or None."""
+    for token in sys.argv[1:]:
+        if token in _TASK_REGISTRY:
+            return token
+    return None
+
+
+def _load_task(name: str):
+    """Import and return the task class for the given subcommand name."""
+    module_path, class_name, _ = _TASK_REGISTRY[name]
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)
+
+
+# Detect the subcommand early so we only import the needed task module.
+_selected_subcommand = _detect_subcommand()
+
+for _name, (_mod, _cls, _help) in _TASK_REGISTRY.items():
+    if _name == _selected_subcommand:
+        # Register the full parser with all subcommands and flags.
+        _load_task(_name).register_parser(sub_parsers, base_subparser)
+    else:
+        # Register a lightweight stub so the command appears in --help.
+        sub_parsers.add_parser(_name, help=_help)
 
 
 def handle(parser: argparse.ArgumentParser, cli_args: List[str] = list()) -> int:

--- a/dbt_coves/core/main.py
+++ b/dbt_coves/core/main.py
@@ -6,7 +6,8 @@ import uuid
 from subprocess import CalledProcessError
 from typing import List
 
-from dbt import tracking, version
+from dbt import tracking
+from dbt import version as dbt_version
 from rich.console import Console
 
 from dbt_coves import __version__
@@ -279,8 +280,8 @@ def main(parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = li
  \\__,_|_.__/ \\__|     \\___\\___/ \\_/ \\___||___/
  """
         console.print(logo_str, style="cyan", highlight=False)
-        dbt_version = version.get_installed_version().to_version_string(skip_matcher=True)
-        console.print(f"dbt-coves v{__version__}".ljust(24) + f"dbt v{dbt_version}\n".rjust(23))
+        installed_dbt = dbt_version.get_installed_version().to_version_string(skip_matcher=True)
+        console.print(f"dbt-coves v{__version__}".ljust(24) + f"dbt v{installed_dbt}\n".rjust(23))
 
     try:
         exit_code = handle(parser, cli_args)  # type: ignore

--- a/dbt_coves/tasks/base.py
+++ b/dbt_coves/tasks/base.py
@@ -1,7 +1,4 @@
-from dbt.task.base import ConfiguredTask
-
 from dbt_coves.core.exceptions import MissingCommand
-from dbt_coves.utils.mp_context import get_mp_context
 
 
 class BaseTask:
@@ -27,79 +24,6 @@ class BaseTask:
 
     def run(self) -> int:
         raise NotImplementedError("Attempt to run unconfigured task")
-
-
-class BaseConfiguredTask(ConfiguredTask, BaseTask):
-    """
-    Task class that requires a configuration
-    """
-
-    needs_config = True
-    needs_dbt_project = True
-
-    def __init__(self, args, config):
-        from dbt.adapters.factory import get_adapter, register_adapter
-        from dbt.context.providers import generate_runtime_macro_context
-        from dbt.parser.manifest import ManifestLoader
-
-        from dbt_coves import __dbt_major_version__, __dbt_minor_version__
-
-        super().__init__(args, config)
-        try:
-            adapter = get_adapter(self.config)
-        except KeyError:
-            if (__dbt_major_version__, __dbt_minor_version__) < (1, 8):
-                register_adapter(self.config)
-            else:
-                register_adapter(self.config, get_mp_context())
-            adapter = get_adapter(self.config)
-
-        if (__dbt_major_version__, __dbt_minor_version__) >= (1, 8):
-            manifest = ManifestLoader.load_macros(
-                self.config,
-                adapter.connections.set_query_header,
-                base_macros_only=True,
-            )
-            adapter.set_macro_resolver(manifest)
-            adapter.set_macro_context_generator(generate_runtime_macro_context)
-
-        self.adapter = adapter
-        self.coves_config = None
-        self.coves_flags = None
-
-    @classmethod
-    def from_args(cls, args):
-        from dbt.config.runtime import RuntimeConfig
-
-        from dbt_coves import __dbt_major_version__, __dbt_minor_version__
-
-        try:
-            from dbt.flags import set_flags
-
-            set_flags(args)
-        except ImportError:
-            pass
-        if (__dbt_major_version__, __dbt_minor_version__) < (1, 8):
-            config = cls.ConfigType.from_args(args)
-        else:
-            from dbt_common.clients.system import get_env
-            from dbt_common.context import set_invocation_context
-
-            set_invocation_context(get_env())
-            config = RuntimeConfig.from_args(args)
-        try:
-            return cls(args, config)
-        # class cannot be instantiated with abstract methods.
-        # that means a subcommand is missing.
-        except TypeError:
-            raise MissingCommand(cls.arg_parser)
-
-    @classmethod
-    def get_instance(cls, flags, coves_config):
-        instance = cls.from_args(flags.args)
-        instance.coves_config = coves_config
-        instance.coves_flags = flags
-        return instance
 
 
 class NonDbtBaseTask(BaseTask):

--- a/dbt_coves/tasks/base.py
+++ b/dbt_coves/tasks/base.py
@@ -1,17 +1,5 @@
-from dbt.adapters.factory import get_adapter, register_adapter
-
-try:
-    from dbt.flags import set_flags
-
-    SET_FLAGS = True
-except ImportError:
-    SET_FLAGS = False
-from dbt.config.runtime import RuntimeConfig
-from dbt.context.providers import generate_runtime_macro_context
-from dbt.parser.manifest import ManifestLoader
 from dbt.task.base import ConfiguredTask
 
-from dbt_coves import __dbt_major_version__, __dbt_minor_version__
 from dbt_coves.core.exceptions import MissingCommand
 from dbt_coves.utils.mp_context import get_mp_context
 
@@ -50,6 +38,12 @@ class BaseConfiguredTask(ConfiguredTask, BaseTask):
     needs_dbt_project = True
 
     def __init__(self, args, config):
+        from dbt.adapters.factory import get_adapter, register_adapter
+        from dbt.context.providers import generate_runtime_macro_context
+        from dbt.parser.manifest import ManifestLoader
+
+        from dbt_coves import __dbt_major_version__, __dbt_minor_version__
+
         super().__init__(args, config)
         try:
             adapter = get_adapter(self.config)
@@ -75,8 +69,16 @@ class BaseConfiguredTask(ConfiguredTask, BaseTask):
 
     @classmethod
     def from_args(cls, args):
-        if SET_FLAGS:
+        from dbt.config.runtime import RuntimeConfig
+
+        from dbt_coves import __dbt_major_version__, __dbt_minor_version__
+
+        try:
+            from dbt.flags import set_flags
+
             set_flags(args)
+        except ImportError:
+            pass
         if (__dbt_major_version__, __dbt_minor_version__) < (1, 8):
             config = cls.ConfigType.from_args(args)
         else:

--- a/dbt_coves/tasks/base_configured.py
+++ b/dbt_coves/tasks/base_configured.py
@@ -1,0 +1,78 @@
+from dbt.task.base import ConfiguredTask
+
+from dbt_coves.core.exceptions import MissingCommand
+from dbt_coves.tasks.base import BaseTask
+from dbt_coves.utils.mp_context import get_mp_context
+
+
+class BaseConfiguredTask(ConfiguredTask, BaseTask):
+    """
+    Task class that requires a dbt configuration and adapter.
+    """
+
+    needs_config = True
+    needs_dbt_project = True
+
+    def __init__(self, args, config):
+        from dbt.adapters.factory import get_adapter, register_adapter
+        from dbt.context.providers import generate_runtime_macro_context
+        from dbt.parser.manifest import ManifestLoader
+
+        from dbt_coves import __dbt_major_version__, __dbt_minor_version__
+
+        super().__init__(args, config)
+        try:
+            adapter = get_adapter(self.config)
+        except KeyError:
+            if (__dbt_major_version__, __dbt_minor_version__) < (1, 8):
+                register_adapter(self.config)
+            else:
+                register_adapter(self.config, get_mp_context())
+            adapter = get_adapter(self.config)
+
+        if (__dbt_major_version__, __dbt_minor_version__) >= (1, 8):
+            manifest = ManifestLoader.load_macros(
+                self.config,
+                adapter.connections.set_query_header,
+                base_macros_only=True,
+            )
+            adapter.set_macro_resolver(manifest)
+            adapter.set_macro_context_generator(generate_runtime_macro_context)
+
+        self.adapter = adapter
+        self.coves_config = None
+        self.coves_flags = None
+
+    @classmethod
+    def from_args(cls, args):
+        from dbt.config.runtime import RuntimeConfig
+
+        from dbt_coves import __dbt_major_version__, __dbt_minor_version__
+
+        try:
+            from dbt.flags import set_flags
+
+            set_flags(args)
+        except ImportError:
+            pass
+        if (__dbt_major_version__, __dbt_minor_version__) < (1, 8):
+            config = cls.ConfigType.from_args(args)
+        else:
+            from dbt_common.clients.system import get_env
+            from dbt_common.context import set_invocation_context
+
+            set_invocation_context(get_env())
+            config = RuntimeConfig.from_args(args)
+        try:
+            return cls(args, config)
+        # class cannot be instantiated with abstract methods.
+        # that means a subcommand is missing.
+        except TypeError:
+            raise MissingCommand(cls.arg_parser)
+
+    @classmethod
+    def get_instance(cls, flags, coves_config):
+        instance = cls.from_args(flags.args)
+        instance.coves_config = coves_config
+        instance.coves_flags = flags
+        return instance

--- a/dbt_coves/tasks/blue_green/clone_db.py
+++ b/dbt_coves/tasks/blue_green/clone_db.py
@@ -2,7 +2,6 @@ import threading
 import time
 
 from rich.console import Console
-from snowflake.connector import DictCursor
 
 console = Console()
 
@@ -66,6 +65,8 @@ class CloneDB:
         Returns:
             None
         """
+        from snowflake.connector import DictCursor
+
         console.print(
             f"Cloning grants from [blue]{self.blue_database}[/blue] to "
             f"green [green]{self.green_database}[/green]"
@@ -96,6 +97,8 @@ class CloneDB:
         Returns:
             None
         """
+        from snowflake.connector import DictCursor
+
         console.print(
             f"Cloning [u]schemas[/u] from [blue]{self.blue_database}[/blue] to "
             f"[green]{self.green_database}[/green]"

--- a/dbt_coves/tasks/blue_green/main.py
+++ b/dbt_coves/tasks/blue_green/main.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 
-import snowflake.connector
 from rich.console import Console
 
 from dbt_coves.core.exceptions import DbtCovesException
@@ -245,6 +244,8 @@ class BlueGreenTask(BaseConfiguredTask):
         )
 
     def snowflake_connection(self):
+        import snowflake.connector
+
         connection_dict = self._get_snowflake_credentials_from_dbt_adapter()
         try:
             return snowflake.connector.connect(**connection_dict)

--- a/dbt_coves/tasks/blue_green/main.py
+++ b/dbt_coves/tasks/blue_green/main.py
@@ -4,7 +4,7 @@ import subprocess
 from rich.console import Console
 
 from dbt_coves.core.exceptions import DbtCovesException
-from dbt_coves.tasks.base import BaseConfiguredTask
+from dbt_coves.tasks.base_configured import BaseConfiguredTask
 from dbt_coves.utils.tracking import trackable
 
 from .clone_db import CloneDB

--- a/dbt_coves/tasks/data_sync/base.py
+++ b/dbt_coves/tasks/data_sync/base.py
@@ -5,13 +5,9 @@ Bring all common (shared across Snowflake and Redshift) dlt functionalities here
 import os
 from datetime import datetime
 
-import dlt
-from dlt.sources.credentials import ConnectionStringCredentials
 from rich.console import Console
 
 from dbt_coves.tasks.base import NonDbtBaseConfiguredTask
-
-from .sql_database import sql_database, sql_table
 
 # These tables are always synced.  Anything else can be requested but that's on user.
 DEFAULT_AIRFLOW_TABLES = [
@@ -50,6 +46,11 @@ class BaseDataSyncTask(NonDbtBaseConfiguredTask):
 
     def perform_sync(self) -> None:
         """Use the sql_database source to completely load all tables in a database"""
+        import dlt
+        from dlt.sources.credentials import ConnectionStringCredentials
+
+        from .sql_database import sql_database, sql_table
+
         # Merge the default table list with the user-requested table list, and split it into
         # incremental and full loads according to if we have an incremental column.
         full_tables = []

--- a/dbt_coves/tasks/extract/main.py
+++ b/dbt_coves/tasks/extract/main.py
@@ -1,6 +1,6 @@
 from rich.console import Console
 
-from dbt_coves.tasks.base import BaseConfiguredTask
+from dbt_coves.tasks.base_configured import BaseConfiguredTask
 
 from .airbyte import ExtractAirbyteTask
 from .fivetran import ExtractFivetranTask

--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -241,9 +241,8 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
             raise GenerateAirflowDagsException(
                 f"YML file [red][b][i]{dag_name}[/i][/b][/red] must contain a 'nodes' section"
             )
-        default_args = {"default_args": yml_dag.pop("default_args", {})}
         extra_imports = yml_dag.pop("imports", [])
-        doc_md = yml_dag.pop("doc_md", None)
+        doc_md = yml_dag.get("doc_md", None)
         self.dag_output = {
             "docstring": [],
             "imports": [
@@ -252,14 +251,11 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
                 *[f"{imp}\n" for imp in extra_imports],
             ],
             "globals": [],
-            "dag": [
-                "@dag(\n",
-                f"{self.dag_args_to_string(default_args)}\n",
-            ],
+            "dag": ["@dag(\n"],
         }
         if doc_md:
             self.dag_output["docstring"].append(f'"""\n{doc_md.rstrip()}\n"""\n\n')
-            yml_dag["doc_md"] = RawExpr("__doc__")
+            yml_dag["doc_md"] = RawExpr("__doc__")  # update in-place to preserve key order
         self.dag_output["dag"].extend(
             [
                 f"{self.dag_args_to_string(yml_dag)}\n",

--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -247,7 +247,6 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
             "docstring": [],
             "imports": [
                 "from airflow.decorators import dag\n",
-                "import datetime\n",
                 *[f"{imp}\n" for imp in extra_imports],
             ],
             "globals": [],

--- a/dbt_coves/tasks/generate/base.py
+++ b/dbt_coves/tasks/generate/base.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from ruamel.yaml import YAML
 from slugify import slugify
 
-from dbt_coves.tasks.base import BaseConfiguredTask
+from dbt_coves.tasks.base_configured import BaseConfiguredTask
 from dbt_coves.utils.jinja import get_render_output, render_template_file
 from dbt_coves.utils.yaml import open_yaml, save_yaml
 

--- a/dbt_coves/tasks/generate/docs.py
+++ b/dbt_coves/tasks/generate/docs.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 from rich.console import Console
 
-from dbt_coves.tasks.base import BaseConfiguredTask
+from dbt_coves.tasks.base_configured import BaseConfiguredTask
 from dbt_coves.tasks.setup.utils import print_row
 from dbt_coves.utils.shell import prepare_cmd, run_and_capture_cwd
 from dbt_coves.utils.tracking import trackable

--- a/dbt_coves/tasks/generate/main.py
+++ b/dbt_coves/tasks/generate/main.py
@@ -1,6 +1,6 @@
 from rich.console import Console
 
-from dbt_coves.tasks.base import BaseConfiguredTask
+from dbt_coves.tasks.base_configured import BaseConfiguredTask
 
 from .airflow_dags import GenerateAirflowDagsTask
 from .docs import GenerateDocsTask

--- a/dbt_coves/tasks/generate/templates.py
+++ b/dbt_coves/tasks/generate/templates.py
@@ -6,7 +6,7 @@ import questionary
 from rich import console
 
 import dbt_coves
-from dbt_coves.tasks.base import BaseConfiguredTask
+from dbt_coves.tasks.base_configured import BaseConfiguredTask
 from dbt_coves.utils.tracking import trackable
 
 console = console.Console()

--- a/dbt_coves/tasks/load/main.py
+++ b/dbt_coves/tasks/load/main.py
@@ -1,6 +1,6 @@
 from rich.console import Console
 
-from dbt_coves.tasks.base import BaseConfiguredTask
+from dbt_coves.tasks.base_configured import BaseConfiguredTask
 
 from .airbyte import LoadAirbyteTask
 from .fivetran import LoadFivetranTask

--- a/dbt_coves/tasks/setup/main.py
+++ b/dbt_coves/tasks/setup/main.py
@@ -6,7 +6,6 @@ import requests
 from jinja2.exceptions import TemplateSyntaxError
 from rich.console import Console
 
-from dbt_coves import __dbt_major_version__, __dbt_minor_version__, __dbt_patch_version__
 from dbt_coves.tasks.base import NonDbtBaseTask
 from dbt_coves.utils.tracking import trackable
 
@@ -72,6 +71,8 @@ class SetupTask(NonDbtBaseTask):
 
     @trackable
     def run(self) -> int:
+        from dbt_coves import __dbt_major_version__, __dbt_minor_version__, __dbt_patch_version__
+
         self.repo_path = os.environ.get("DATACOVES__REPO_PATH", Path().resolve())
         self.copier_context = {"no_prompt": self.get_config_value("no_prompt")}
         self.copier_context["dbt_core_version"] = (


### PR DESCRIPTION
Previously all possible libraries were imported when dbt-coves started, regardless of the task being run.  This makes imports somewhat lazier and thus improves performance.  Two maintenance items are along for the ride:
- Stop importing `datetime` in generated Airflow DAGs (it can be added back as needed by end user as a custom import)
- Exempt Dependabot from CI checks involving secrets it does not have access to