### PR TITLE
[dcv-3932] dbt support to <2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,31 @@
 repos:
   - repo: local
     hooks:
-      # Format.
-      - id: black
-        name: black
-        entry: black
+      # DCV-3932: ruff replaces black + isort + flake8 + debug-statements.
+      # Lint with autofix (isort I, flake8-debugger T10, pyflakes, pycodestyle).
+      # --force-exclude makes ruff honor extend-exclude even when pre-commit
+      # passes file paths explicitly (otherwise excluded dirs like migrations/
+      # get linted/formatted).
+      - id: ruff-check
+        name: ruff check
+        entry: ruff check --force-exclude --fix
         language: python
         language_version: python3
-        additional_dependencies: ["black>=25,<26"]
-        minimum_pre_commit_version: 2.9.2
+        additional_dependencies: [ruff==0.15.19]
         require_serial: true
-        types_or: [cython, pyi, python]
-      - id: isort
-        name: isort
-        entry: isort
+        types_or: [pyi, python]
+      # Format (black-compatible).
+      - id: ruff-format
+        name: ruff format
+        entry: ruff format --force-exclude
+        language: python
+        language_version: python3
+        additional_dependencies: [ruff==0.15.19]
         require_serial: true
-        language: python
-        language_version: python3
-        additional_dependencies: ["isort>=5.12.0,<6"]
-        types_or: [cython, pyi, python]
-        args: ["--profile", "black", "./dbt_coves", "./scripts"]
-      # Lint
-      - id: linter
-        name: linter
-        entry: flake8
-        language: python
-        language_version: python3
-        additional_dependencies: ["flake8>=7.1.0,<8"]
-        types_or: [cython, pyi, python]
+        types_or: [pyi, python]
       - id: prevent-push-to-main
         name: Prevent push to main
         entry: bash ./scripts/pre-commit-hooks/prevent-push-to-main.sh
         language: system
         stages: [pre-commit, pre-push]
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0  # Use the ref you want to point at
-    hooks:
-    -   id: debug-statements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,9 +113,7 @@ If you don't want to bother, that's also OK because we also have [pre-commit.ci]
 
 #### Formatting (Enforced by pre-commit)
 
-- We format our code with the [`black`](https://github.com/psf/black) formatter. The pre-commit hooks will attempt to fix your formatting issues for you but it's "annoying" so you can set up `black` to format your code on save in your IDE and then you'll never have a problem again. The good thing with black is that we don't ever have to discuss formatting and style while reviewing your PR which is soooooo much nicer! :heart_eyes:
-
-- [`flake8`](https://flake8.pycqa.org/en/latest/) is also part of our pre-commit config. If you do not have it installed as a linter in your IDE or you ignore its recommendation `pre-commit` will fail. **flake8 in precommits does not automatically fix your files** so it's better to enforce it's advice during developments but that's up to you.
+- We format and lint our code with [`ruff`](https://github.com/astral-sh/ruff). The pre-commit hooks will attempt to fix your formatting and lint issues for you but it's "annoying" so you can set up `ruff` to format your code on save in your IDE and then you'll never have a problem again. The good thing with ruff is that we don't ever have to discuss formatting and style while reviewing your PR which is soooooo much nicer! :heart_eyes:
 
 - Finally, **trailing whitespace** and **empty new line at end of file** will also be enforced for you by `pre-commit` either during PR time or locally if you have set it up according to [our guidelines](#pre-commit).
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you're interested in contributing to the development of dbt-coves, please ref
 
 # Metrics
 
-[![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/datacoves/dbt-coves/graphs/commit-activity)
 [![Maintainability](https://api.codeclimate.com/v1/badges/1e6a887de605ef8e0eca/maintainability)](https://codeclimate.com/github/datacoves/dbt-coves/maintainability)
 [![Downloads](https://pepy.tech/badge/dbt-coves)](https://pepy.tech/project/dbt-coves)

--- a/dbt_coves/__init__.py
+++ b/dbt_coves/__init__.py
@@ -2,7 +2,11 @@ __version__ = "1.11.3"
 
 
 def __getattr__(name: str):
-    if name in ("__dbt_major_version__", "__dbt_minor_version__", "__dbt_patch_version__"):
+    if name in (
+        "__dbt_major_version__",
+        "__dbt_minor_version__",
+        "__dbt_patch_version__",
+    ):
         import dbt.version
 
         v = dbt.version.installed

--- a/dbt_coves/config/config.py
+++ b/dbt_coves/config/config.py
@@ -31,7 +31,9 @@ class GenerateSourcesModel(BaseModel):
     exclude_relations: Optional[List[str]] = []
     sources_destination: Optional[str] = "models/staging/{{schema}}/{{schema}}.yml"
     models_destination: Optional[str] = "models/staging/{{schema}}/{{relation}}.sql"
-    model_props_destination: Optional[str] = "models/staging/{{schema}}/{{relation}}.yml"
+    model_props_destination: Optional[str] = (
+        "models/staging/{{schema}}/{{relation}}.yml"
+    )
     update_strategy: Optional[str] = "ask"
     templates_folder: Optional[str] = ".dbt_coves/templates"
     metadata: Optional[str] = ""
@@ -305,7 +307,11 @@ class DbtCovesConfig:
             source = self._flags
             for item in path_items[:-1]:
                 target = target[item]
-                source = source.get(item, {}) if type(source) is dict else getattr(source, item)
+                source = (
+                    source.get(item, {})
+                    if type(source) is dict
+                    else getattr(source, item)
+                )
             key = path_items[-1]
             if source.get(key):
                 target[key] = source[key]
@@ -366,7 +372,9 @@ class DbtCovesConfig:
             logger.debug("Trying to find .dbt_coves in current folder")
 
             for filename in self.DBT_COVES_CONFIG_FILEPATHS:
-                config_path = Path(os.environ.get("DATACOVES__DBT_HOME", "")).joinpath(filename)
+                config_path = Path(os.environ.get("DATACOVES__DBT_HOME", "")).joinpath(
+                    filename
+                )
                 if config_path.exists():
                     coves_config_dir = config_path
                     logger.debug(f"{coves_config_dir} exists and was retrieved.")

--- a/dbt_coves/core/main.py
+++ b/dbt_coves/core/main.py
@@ -316,7 +316,9 @@ def handle(parser: argparse.ArgumentParser, cli_args: List[str] = list()) -> int
     return task_cls.get_instance(main_parser, coves_config=coves_config).run()
 
 
-def main(parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = list()) -> int:
+def main(
+    parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = list()
+) -> int:
     tracking.do_not_track()
 
     exit_code = 0
@@ -332,8 +334,12 @@ def main(parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = li
  \\__,_|_.__/ \\__|     \\___\\___/ \\_/ \\___||___/
  """
         console.print(logo_str, style="cyan", highlight=False)
-        installed_dbt = dbt_version.get_installed_version().to_version_string(skip_matcher=True)
-        console.print(f"dbt-coves v{__version__}".ljust(24) + f"dbt v{installed_dbt}\n".rjust(23))
+        installed_dbt = dbt_version.get_installed_version().to_version_string(
+            skip_matcher=True
+        )
+        console.print(
+            f"dbt-coves v{__version__}".ljust(24) + f"dbt v{installed_dbt}\n".rjust(23)
+        )
 
     try:
         exit_code = handle(parser, cli_args)  # type: ignore

--- a/dbt_coves/tasks/blue_green/clone_db.py
+++ b/dbt_coves/tasks/blue_green/clone_db.py
@@ -14,7 +14,11 @@ class CloneDB:
     """
 
     def __init__(
-        self, blue_database: str, green_database: str, snowflake_conn, thread_count: int = 20
+        self,
+        blue_database: str,
+        green_database: str,
+        snowflake_conn,
+        thread_count: int = 20,
     ):
         """
         Blue/Green deployment for Snowflake databases.
@@ -130,7 +134,9 @@ class CloneDB:
         )
         for schema in schemas:
             if schema["name"] not in self._list_of_schemas_to_exclude:
-                grants_sql_stg_1 = f"""show grants on schema {blue_database}.{schema['name']}"""
+                grants_sql_stg_1 = (
+                    f"""show grants on schema {blue_database}.{schema["name"]}"""
+                )
                 dict_cursor.execute(grants_sql_stg_1)
                 grants = dict_cursor.fetchall()
                 for grant in grants:
@@ -194,7 +200,9 @@ class ThreadedRunCommands:
             self.pending_queries = [
                 q
                 for q in self.pending_queries
-                if self.con.is_still_running(self.con.get_query_status_throw_if_error(q))
+                if self.con.is_still_running(
+                    self.con.get_query_status_throw_if_error(q)
+                )
             ]
             console.print(
                 f"Waiting for {len(self.pending_queries)} queries to complete before continuing."

--- a/dbt_coves/tasks/blue_green/main.py
+++ b/dbt_coves/tasks/blue_green/main.py
@@ -69,7 +69,9 @@ class BlueGreenTask(BaseConfiguredTask):
             action="store_true",
             help="Perform a full dbt build",
         )
-        ext_subparser.add_argument("--defer", action="store_true", help="Run in deferral")
+        ext_subparser.add_argument(
+            "--defer", action="store_true", help="Run in deferral"
+        )
         return ext_subparser
 
     def get_config_value(self, key):
@@ -89,16 +91,22 @@ class BlueGreenTask(BaseConfiguredTask):
         staging_database = self.get_config_value("staging_database")
         staging_suffix = self.get_config_value("staging_suffix")
         if staging_database and staging_suffix:
-            raise DbtCovesException("Cannot specify both staging_database and staging_suffix")
+            raise DbtCovesException(
+                "Cannot specify both staging_database and staging_suffix"
+            )
         elif not staging_database and not staging_suffix:
             staging_suffix = "STAGING"
-        self.staging_database = staging_database or f"{self.production_database}_{staging_suffix}"
+        self.staging_database = (
+            staging_database or f"{self.production_database}_{staging_suffix}"
+        )
         if self.production_database == self.staging_database:
             raise DbtCovesException(
                 f"Production database {self.production_database} cannot be the same as staging "
                 f"database {self.staging_database}"
             )
-        self.drop_staging_db_at_start = self.get_config_value("drop_staging_db_at_start")
+        self.drop_staging_db_at_start = self.get_config_value(
+            "drop_staging_db_at_start"
+        )
 
         self.cdb = CloneDB(
             self.production_database,
@@ -112,11 +120,15 @@ class BlueGreenTask(BaseConfiguredTask):
             # create staging db
             self.cdb.create_database(self.staging_database)
             # clones schemas and schema grants from production to pre_production
-            self.cdb.clone_database_schemas(self.production_database, self.staging_database)
+            self.cdb.clone_database_schemas(
+                self.production_database, self.staging_database
+            )
             # run dbt build
             self._run_dbt_build(env)
             # copy db grants from production db
-            self.cdb.clone_database_grants(self.production_database, self.staging_database)
+            self.cdb.clone_database_grants(
+                self.production_database, self.staging_database
+            )
             # Swaps databases: Snowflake sql `alter database {blue} swap with {green}`
             self._swap_databases()
             # drops pre_production (ex production)
@@ -145,7 +157,9 @@ class BlueGreenTask(BaseConfiguredTask):
             )
             console.print(f"[green]{command_string} :heavy_check_mark:[/green]")
         except subprocess.CalledProcessError as e:
-            console.print(f"Error running [red]{e.cmd}[/red], see stack above for details")
+            console.print(
+                f"Error running [red]{e.cmd}[/red], see stack above for details"
+            )
             raise
 
     def _get_dbt_command(self, command):

--- a/dbt_coves/tasks/data_sync/base.py
+++ b/dbt_coves/tasks/data_sync/base.py
@@ -39,9 +39,11 @@ console = Console()
 
 class BaseDataSyncTask(NonDbtBaseConfiguredTask):
     def get_source_connection_string(self):
-        self.source_connection_string = os.environ.get("DATA_SYNC_SOURCE_CONNECTION_STRING")
+        self.source_connection_string = os.environ.get(
+            "DATA_SYNC_SOURCE_CONNECTION_STRING"
+        )
         assert self.source_connection_string, (
-            "Environment variable " "DATA_SYNC_SOURCE_CONNECTION_STRING is not defined"
+            "Environment variable DATA_SYNC_SOURCE_CONNECTION_STRING is not defined"
         )
 
     def perform_sync(self) -> None:

--- a/dbt_coves/tasks/data_sync/main.py
+++ b/dbt_coves/tasks/data_sync/main.py
@@ -23,7 +23,9 @@ class DataSyncTask(BaseTask):
             help="Upload Airflow tables to Snowflake or Redshift",
         )
         subparser.set_defaults(cls=cls, which="data_sync")
-        sub_parsers = subparser.add_subparsers(title="dbt-coves data-sync commands", dest="task")
+        sub_parsers = subparser.add_subparsers(
+            title="dbt-coves data-sync commands", dest="task"
+        )
         SnowflakeDataSyncTask.register_parser(sub_parsers, base_subparser)
         RedshiftDataSyncTask.register_parser(sub_parsers, base_subparser)
         cls.arg_parser = subparser

--- a/dbt_coves/tasks/data_sync/redshift.py
+++ b/dbt_coves/tasks/data_sync/redshift.py
@@ -34,7 +34,9 @@ class RedshiftDataSyncTask(BaseDataSyncTask):
             parents=[base_subparser],
             help="""Loads data into Redshift""",
         )
-        subparser.add_argument("--tables", help="List of tables to dump", required=False)
+        subparser.add_argument(
+            "--tables", help="List of tables to dump", required=False
+        )
         subparser.add_argument("--source", help="Source database name", required=True)
         subparser.set_defaults(cls=cls, which="redshift")
         return subparser

--- a/dbt_coves/tasks/data_sync/snowflake.py
+++ b/dbt_coves/tasks/data_sync/snowflake.py
@@ -54,7 +54,9 @@ class SnowflakeDataSyncTask(BaseDataSyncTask):
             parents=[base_subparser],
             help="""Loads data into Snowflake""",
         )
-        subparser.add_argument("--tables", help="List of tables to dump", required=False)
+        subparser.add_argument(
+            "--tables", help="List of tables to dump", required=False
+        )
         subparser.add_argument("--source", help="Source database name", required=True)
         subparser.set_defaults(cls=cls, which="snowflake")
         return subparser

--- a/dbt_coves/tasks/data_sync/sql_database/__init__.py
+++ b/dbt_coves/tasks/data_sync/sql_database/__init__.py
@@ -140,7 +140,9 @@ def sql_table(
     engine.execution_options(stream_results=True, max_row_buffer=2 * chunk_size)
     metadata = metadata or MetaData(schema=schema)
 
-    table_obj = Table(table, metadata, autoload_with=None if defer_table_reflect else engine)
+    table_obj = Table(
+        table, metadata, autoload_with=None if defer_table_reflect else engine
+    )
     if table_adapter_callback and not defer_table_reflect:
         table_adapter_callback(table_obj)
 

--- a/dbt_coves/tasks/data_sync/sql_database/helpers.py
+++ b/dbt_coves/tasks/data_sync/sql_database/helpers.py
@@ -95,7 +95,9 @@ def table_rows(
     table_adapter_callback: Callable[[Table], None] = None,
 ) -> Iterator[TDataItem]:
     if defer_table_reflect:
-        table = Table(table.name, table.metadata, autoload_with=engine, extend_existing=True)
+        table = Table(
+            table.name, table.metadata, autoload_with=engine, extend_existing=True
+        )
         if table_adapter_callback:
             table_adapter_callback(table)
         # set the primary_key in the incremental
@@ -116,7 +118,9 @@ def table_rows(
     yield from loader.load_rows()
 
 
-def engine_from_credentials(credentials: Union[ConnectionStringCredentials, Engine, str]) -> Engine:
+def engine_from_credentials(
+    credentials: Union[ConnectionStringCredentials, Engine, str],
+) -> Engine:
     if isinstance(credentials, Engine):
         return credentials
     if isinstance(credentials, ConnectionStringCredentials):

--- a/dbt_coves/tasks/dbt/main.py
+++ b/dbt_coves/tasks/dbt/main.py
@@ -62,7 +62,9 @@ class RunDbtTask(NonDbtBaseConfiguredTask):
     def run(self) -> int:
         project_dir = self.get_config_value("project_dir")
         if not project_dir:
-            project_dir = os.environ.get("DBT_PROJECT_DIR", os.environ.get("DATACOVES__DBT_HOME"))
+            project_dir = os.environ.get(
+                "DBT_PROJECT_DIR", os.environ.get("DATACOVES__DBT_HOME")
+            )
         if not project_dir:
             console.print("[red]No dbt project specified[/red].")
             return -1
@@ -87,7 +89,9 @@ class RunDbtTask(NonDbtBaseConfiguredTask):
                     console.print("Removing cloned read-write copy.")
                     shutil.rmtree(tmp_dir, ignore_errors=True)
                 else:
-                    console.print("Writing dbt clone path to '/tmp/dbt_coves_dbt_clone_path.txt'.")
+                    console.print(
+                        "Writing dbt clone path to '/tmp/dbt_coves_dbt_clone_path.txt'."
+                    )
                     with open(path_file, "w") as f:
                         f.write(tmp_dir)
         else:
@@ -127,12 +131,16 @@ class RunDbtTask(NonDbtBaseConfiguredTask):
             # conflicts with trailing / at later concatenation
             env_path = Path(os.environ.get(virtualenv, virtualenv))
         if env_path and env_path.exists():
-            cmd_list = shlex.split(f"/bin/bash -c 'source {env_path}/bin/activate && {command}'")
+            cmd_list = shlex.split(
+                f"/bin/bash -c 'source {env_path}/bin/activate && {command}'"
+            )
         else:
             cmd_list = shlex.split(command)
 
         try:
-            output = subprocess.check_output(cmd_list, env=env, cwd=cwd, stderr=subprocess.PIPE)
+            output = subprocess.check_output(
+                cmd_list, env=env, cwd=cwd, stderr=subprocess.PIPE
+            )
             console.print(
                 f"{Text.from_ansi(output.decode())}\n"
                 f"[green]{command} :heavy_check_mark:[/green]"
@@ -142,7 +150,9 @@ class RunDbtTask(NonDbtBaseConfiguredTask):
                 formatted = str(Text.from_ansi(e.stderr.decode()))
             else:
                 formatted = str(Text.from_ansi(e.stdout.decode()))
-            e.stderr = f"An error has occurred running [red]{command}[/red]:\n{formatted}"
+            e.stderr = (
+                f"An error has occurred running [red]{command}[/red]:\n{formatted}"
+            )
             raise
 
     def get_config_value(self, key):

--- a/dbt_coves/tasks/extract/airbyte.py
+++ b/dbt_coves/tasks/extract/airbyte.py
@@ -143,7 +143,10 @@ class ExtractAirbyteTask(BaseExtractTask):
             repo = definition.get("dockerRepository", "")
             repo_suffix = repo.split("/")[-1]  # e.g. "source-postgres"
             expected = f"source-{connector_type}"
-            if repo_suffix == expected or repo_suffix == f"destination-{connector_type}":
+            if (
+                repo_suffix == expected
+                or repo_suffix == f"destination-{connector_type}"
+            ):
                 def_id = definition.get("sourceDefinitionId") or definition.get(
                     "destinationDefinitionId"
                 )
@@ -180,13 +183,19 @@ class ExtractAirbyteTask(BaseExtractTask):
 
                 # We may or may not get secrets information from Airbyte.
                 if spec:
-                    airbyte_secret_fields = self._get_airbyte_secret_fields_for_definition(spec)
-                    destination["configuration"] = self._hide_configuration_secret_fields(
-                        destination.get("configuration", {}), airbyte_secret_fields
+                    airbyte_secret_fields = (
+                        self._get_airbyte_secret_fields_for_definition(spec)
+                    )
+                    destination["configuration"] = (
+                        self._hide_configuration_secret_fields(
+                            destination.get("configuration", {}), airbyte_secret_fields
+                        )
                     )
 
                 destination["connectorVersion"] = self._get_connector_version(
-                    destination_type, self.airbyte_api.destination_definitions, "destination"
+                    destination_type,
+                    self.airbyte_api.destination_definitions,
+                    "destination",
                 )
                 return destination
 
@@ -219,7 +228,9 @@ class ExtractAirbyteTask(BaseExtractTask):
 
                 # Try to get secrets information, if there is any.
                 if spec:
-                    airbyte_secret_fields = self._get_airbyte_secret_fields_for_definition(spec)
+                    airbyte_secret_fields = (
+                        self._get_airbyte_secret_fields_for_definition(spec)
+                    )
                     source["configuration"] = self._hide_configuration_secret_fields(
                         source.get("configuration", {}), airbyte_secret_fields
                     )
@@ -250,7 +261,10 @@ class ExtractAirbyteTask(BaseExtractTask):
                     self._get_airbyte_secret_fields_for_definition(v, k, secret_fields)
                 else:
                     if "airbyte_secret" in str(k):
-                        if bool(definition["airbyte_secret"]) and dict_name not in secret_fields:
+                        if (
+                            bool(definition["airbyte_secret"])
+                            and dict_name not in secret_fields
+                        ):
                             secret_fields.append(dict_name)
             return secret_fields
         except KeyError as e:
@@ -278,7 +292,9 @@ class ExtractAirbyteTask(BaseExtractTask):
         connection = copy(connection)
         connection.pop("connectionId", None)
 
-        connection_source_name = self._get_airbyte_source_from_id(connection["sourceId"])["name"]
+        connection_source_name = self._get_airbyte_source_from_id(
+            connection["sourceId"]
+        )["name"]
         connection_destination_name = self._get_airbyte_destination_from_id(
             connection["destinationId"]
         )["name"]

--- a/dbt_coves/tasks/extract/main.py
+++ b/dbt_coves/tasks/extract/main.py
@@ -23,7 +23,9 @@ class ExtractTask(BaseConfiguredTask):
             help="Extract configuration data from Airbyte or Fivetran",
         )
         ext_subparser.set_defaults(cls=cls, which="extract")
-        sub_parsers = ext_subparser.add_subparsers(title="dbt-coves extract commands", dest="task")
+        sub_parsers = ext_subparser.add_subparsers(
+            title="dbt-coves extract commands", dest="task"
+        )
         ExtractAirbyteTask.register_parser(sub_parsers, base_subparser)
         ExtractFivetranTask.register_parser(sub_parsers, base_subparser)
         cls.arg_parser = ext_subparser

--- a/dbt_coves/tasks/generate/airflow_dags.py
+++ b/dbt_coves/tasks/generate/airflow_dags.py
@@ -94,12 +94,18 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
             type=str,
             help="Secret credentials provider, i.e. 'datacoves'",
         )
-        subparser.add_argument("--secrets-url", type=str, help="Secret credentials provider url")
+        subparser.add_argument(
+            "--secrets-url", type=str, help="Secret credentials provider url"
+        )
         subparser.add_argument(
             "--secrets-token", type=str, help="Secret credentials provider token"
         )
-        subparser.add_argument("--secrets-environment", type=str, help="Secret credentials project")
-        subparser.add_argument("--secrets-tags", type=str, help="Secret credentials tags")
+        subparser.add_argument(
+            "--secrets-environment", type=str, help="Secret credentials project"
+        )
+        subparser.add_argument(
+            "--secrets-tags", type=str, help="Secret credentials tags"
+        )
         subparser.add_argument("--secrets-key", type=str, help="Secret credentials key")
 
         cls.arg_parser = base_subparser
@@ -122,7 +128,9 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         return self.coves_config.integrated["generate"]["airflow_dags"][key]
 
     def _generate_dag(self, yml_filepath: Path):
-        yaml.FullLoader.add_constructor("tag:yaml.org,2002:timestamp", self.date_constructor)
+        yaml.FullLoader.add_constructor(
+            "tag:yaml.org,2002:timestamp", self.date_constructor
+        )
         yaml.FullLoader.add_constructor("!py", self.raw_expr_constructor)
         console.print(f"Generating [b][i]{yml_filepath.stem}[/i][/b]")
         try:
@@ -136,7 +144,10 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
                 else:
                     yml_relpath = yml_filepath.name
                 dag_destination = (
-                    Path(self.dags_path).resolve().joinpath(yml_relpath).with_suffix(".py")
+                    Path(self.dags_path)
+                    .resolve()
+                    .joinpath(yml_relpath)
+                    .with_suffix(".py")
                 )
             else:
                 dag_destination = yml_filepath.with_suffix(".py")
@@ -188,7 +199,7 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
                     dag_value = f'"{value}"'
                 else:
                     dag_value = value
-                dag_args += f'{indent * " "}{key}={dag_value},\n'
+                dag_args += f"{indent * ' '}{key}={dag_value},\n"
         return dag_args[:-1]
 
     def generate_notifiers(self, notifiers: Dict[str, Any]):
@@ -208,7 +219,9 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
             module = ".".join(split_callback[:-1])
             callback_class = split_callback[-1]
             callback_args = definition.get("args")
-            self.dag_output["imports"].append(f"from {module} import {callback_class}\n")
+            self.dag_output["imports"].append(
+                f"from {module} import {callback_class}\n"
+            )
             usage_args = []
             if isinstance(callback_args, dict):
                 for arg, value in callback_args.items():
@@ -228,7 +241,9 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
             callback_output.append(f"{2 * ' '}{callback}={callback_usage}")
         return callback_output
 
-    def build_dag_file(self, destination_path: Path, dag_name: str, yml_dag: Dict[str, Any]):
+    def build_dag_file(
+        self, destination_path: Path, dag_name: str, yml_dag: Dict[str, Any]
+    ):
         """
         Generate DAG Python file based on YML configuration
         """
@@ -254,7 +269,9 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         }
         if doc_md:
             self.dag_output["docstring"].append(f'"""\n{doc_md.rstrip()}\n"""\n\n')
-            yml_dag["doc_md"] = RawExpr("__doc__")  # update in-place to preserve key order
+            yml_dag["doc_md"] = RawExpr(
+                "__doc__"
+            )  # update in-place to preserve key order
         self.dag_output["dag"].extend(
             [
                 f"{self.dag_args_to_string(yml_dag)}\n",
@@ -265,7 +282,9 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         for node_name, node_conf in nodes.items():
             self.generate_node(node_name, node_conf)
         for upstream_list, task_name in self.collected_dependencies:
-            self.dag_output["dag"].append(f"    [{', '.join(upstream_list)}] >> {task_name}\n")
+            self.dag_output["dag"].append(
+                f"    [{', '.join(upstream_list)}] >> {task_name}\n"
+            )
         self.dag_output["dag"].append(f"dag = {dag_name}()\n")
 
         with open(destination_path, "w") as f:
@@ -281,7 +300,9 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
                 f.write(isort_formatted)
             except Exception as exc:
                 f.write(final_output)
-                console.print(f"DAG {dag_name} resulted in an invalid DAG, skipping. Error: {exc}")
+                console.print(
+                    f"DAG {dag_name} resulted in an invalid DAG, skipping. Error: {exc}"
+                )
 
     def _merge_secret_nodes(self, secret_nodes, yml_dag) -> Dict[str, Any]:
         if isinstance(secret_nodes, dict):
@@ -336,7 +357,9 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         )
         return getattr(module, generator)
 
-    def _merge_generator_configs(self, tg_conf: Dict[str, Any], generator: str) -> Dict[str, Any]:
+    def _merge_generator_configs(
+        self, tg_conf: Dict[str, Any], generator: str
+    ) -> Dict[str, Any]:
         """
         Merge the generator configs between YML Dag and dbt-coves `generators_params` config
         """
@@ -350,7 +373,11 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         """
         Generate Task Groups, using YML's `generator` or `tasks`
         """
-        self.dag_output["imports"].append("from airflow.decorators import task_group\n"),
+        (
+            self.dag_output["imports"].append(
+                "from airflow.decorators import task_group\n"
+            ),
+        )
         tg_tooltip = tg_conf.pop("tooltip", "")
         task_group_output = [
             f"{' ' * 4}@task_group(group_id='{tg_name}', tooltip='{tg_tooltip}',)\n",
@@ -389,7 +416,9 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
 
         if len(task_group_output) == 2:
             # No tasks were added — emit pass to keep the function body valid
-            task_group_output.append(f"{' ' * 8}pass # XXX dbt-coves did not receive a task here\n")
+            task_group_output.append(
+                f"{' ' * 8}pass # XXX dbt-coves did not receive a task here\n"
+            )
 
         tg_variable_name = f"tg_{tg_name}"
         task_group_output.append(f"{' ' * 4}{tg_variable_name} = {tg_name}()\n")
@@ -443,7 +472,9 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
             f"{config_global_name}="
             f"{AIRFLOW_K8S_CONFIG_TEMPLATE.format(config=inner_config_lines)}\n"
         )
-        self.dag_output["imports"].append("from kubernetes.client import models as k8s\n")
+        self.dag_output["imports"].append(
+            "from kubernetes.client import models as k8s\n"
+        )
         task_conf["executor_config"] = config_global_name
 
     def generate_task_output(
@@ -466,7 +497,9 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
             # Extract additional arguments for the decorator
             decorator_args = []
             for key, value in task_conf.items():
-                if isinstance(value, dict):  # Handle nested dictionaries (e.g., overrides)
+                if isinstance(
+                    value, dict
+                ):  # Handle nested dictionaries (e.g., overrides)
                     value = f"{value}"  # Render as a Python dictionary
                 elif isinstance(value, str):
                     value = f'"{value}"'
@@ -478,7 +511,7 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
                 f"{' ' * (indent + 4)}{', '.join(decorator_args)},\n",
                 f"{' ' * indent})\n",
                 f"{' ' * indent}def {task_name}():\n",
-                f"{' ' * (indent + 4)}return \"{bash_command}\"\n",
+                f'{" " * (indent + 4)}return "{bash_command}"\n',
                 f"{' ' * (indent)}{task_name} = {task_name}()\n",
             ]
         else:
@@ -503,7 +536,9 @@ class GenerateAirflowDagsTask(NonDbtBaseTask):
         if dependencies:
             upstream_list = [self.generated_groups.get(d, d) for d in dependencies]
             if is_task_taskgroup:
-                task_output.append(f"{' ' * indent}[{', '.join(upstream_list)}] >> {task_name} \n")
+                task_output.append(
+                    f"{' ' * indent}[{', '.join(upstream_list)}] >> {task_name} \n"
+                )
             else:
                 self.collected_dependencies.append((upstream_list, task_name))
         return task_output

--- a/dbt_coves/tasks/generate/airflow_generators/airbyte.py
+++ b/dbt_coves/tasks/generate/airflow_generators/airbyte.py
@@ -29,7 +29,9 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
         self.airbyte_conn_id = airbyte_conn_id
         self.connection_ids = connection_ids
         self.ignored_source_tables = []
-        self.imports = ["airflow.providers.airbyte.operators.airbyte.AirbyteTriggerSyncOperator"]
+        self.imports = [
+            "airflow.providers.airbyte.operators.airbyte.AirbyteTriggerSyncOperator"
+        ]
         self.api_caller = AirbyteApiCaller(
             self.host, api_port=self.port or None, api_key=self.api_key or None
         )
@@ -41,7 +43,9 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
         Ensure connection_ids exist in Airbyte API
         """
         for conn in connection_ids:
-            if conn not in (connection["connectionId"] for connection in self.airbyte_connections):
+            if conn not in (
+                connection["connectionId"] for connection in self.airbyte_connections
+            ):
                 raise AirbyteGeneratorException(
                     f"Airbyte error: there is no Airbyte connection for id [red]{conn}[/red]"
                 )
@@ -69,7 +73,9 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
         for destination in self.api_caller.destinations_list:
             if destination["destinationId"] == id:
                 return destination
-        raise AirbyteGeneratorException(f"Airbyte error: there are no destinations for id {id}")
+        raise AirbyteGeneratorException(
+            f"Airbyte error: there are no destinations for id {id}"
+        )
 
     def _get_airbyte_source(self, id):
         """Get the complete Source object from it's ID"""
@@ -90,7 +96,9 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
             and conn["namespaceFormat"] == "${SOURCE_NAMESPACE}"
         ):
             source = self._get_airbyte_source(conn["sourceId"])
-            source_config = source.get("configuration", source.get("connectionConfiguration", {}))
+            source_config = source.get(
+                "configuration", source.get("connectionConfiguration", {})
+            )
             if "schema" in source_config:
                 return source_config["schema"].lower()
             else:
@@ -108,7 +116,10 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
         airbyte_tables = []
         connection_ids = []
         for conn in list(
-            filter(lambda conn: conn.get("status") != "deprecated", self.airbyte_connections)
+            filter(
+                lambda conn: conn.get("status") != "deprecated",
+                self.airbyte_connections,
+            )
         ):
             # Handle both old syncCatalog and new configurations API formats
             catalog = conn.get("syncCatalog") or conn.get("configurations", {})
@@ -133,11 +144,13 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
                             "database", destination_config.get("project-id", "")
                         ).lower()
                     ):
-                        airbyte_schema = self._get_connection_schema(conn, destination_config)
+                        airbyte_schema = self._get_connection_schema(
+                            conn, destination_config
+                        )
                         # and finally, match schema, if defined
-                        if (airbyte_schema == schema or not airbyte_schema) and conn.get(
-                            "connectionId"
-                        ) not in connection_ids:
+                        if (
+                            airbyte_schema == schema or not airbyte_schema
+                        ) and conn.get("connectionId") not in connection_ids:
                             connection_ids.append(conn["connectionId"])
         if connection_ids:
             return connection_ids
@@ -154,7 +167,9 @@ class AirbyteGenerator(BaseDbtCovesTaskGenerator):
         for conn in self.airbyte_connections:
             if conn["connectionId"] == conn_id:
                 source_name = self._get_airbyte_source(conn["sourceId"])["name"]
-                destination_name = self._get_airbyte_destination(conn["destinationId"])["name"]
+                destination_name = self._get_airbyte_destination(conn["destinationId"])[
+                    "name"
+                ]
                 return slugify(f"{source_name} → {destination_name}", separator="_")
 
         raise AirbyteGeneratorException(

--- a/dbt_coves/tasks/generate/airflow_generators/base.py
+++ b/dbt_coves/tasks/generate/airflow_generators/base.py
@@ -39,7 +39,9 @@ class BaseDbtGenerator:
         Discover DBT source(s)' Airbyte/Fivetran connection IDs based on params
         """
         if self.virtualenv_path:
-            self.virtualenv_path = Path(f"{self.virtualenv_path}/bin/activate").absolute()
+            self.virtualenv_path = Path(
+                f"{self.virtualenv_path}/bin/activate"
+            ).absolute()
 
         if Path(self.dbt_project_path).is_absolute():
             self.dbt_project_path = Path(self.dbt_project_path)
@@ -60,7 +62,9 @@ class BaseDbtGenerator:
             ).stdout.strip("\n")
             deploy_path = "/tmp/airbyte-generator-" + commit
             # Move folders
-            subprocess.run(["cp", "-rf", self.dbt_project_path, deploy_path], check=True)
+            subprocess.run(
+                ["cp", "-rf", self.dbt_project_path, deploy_path], check=True
+            )
             cwd = deploy_path
 
         try:
@@ -96,7 +100,8 @@ class BaseDbtGenerator:
 
             if self.virtualenv_path:
                 command = self.get_bash_command(
-                    self.virtualenv_path, f"dbt ls --resource-type source {self.dbt_list_args}"
+                    self.virtualenv_path,
+                    f"dbt ls --resource-type source {self.dbt_list_args}",
                 )
             else:
                 command = [
@@ -121,7 +126,9 @@ class BaseDbtGenerator:
                 error_message += f"{e.stdout.decode()}\n"
             if e.stderr:
                 error_message += f"{e.stderr.decode()}"
-            raise GeneratorException(f"Exception occurred running {command}\n{error_message}")
+            raise GeneratorException(
+                f"Exception occurred running {command}\n{error_message}"
+            )
 
         sources_list = []
         if "No nodes selected" not in stdout:
@@ -169,7 +176,8 @@ class BaseDbtCovesTaskGenerator:
         Returns Airflow call as a string
         """
         func_call = ", ".join(
-            f'{k}="{v}"' if isinstance(v, str) else f"{k}={v}" for k, v in kwargs.items()
+            f'{k}="{v}"' if isinstance(v, str) else f"{k}={v}"
+            for k, v in kwargs.items()
         )
         return f"{name} = {operator}({func_call})"
 

--- a/dbt_coves/tasks/generate/airflow_generators/fivetran.py
+++ b/dbt_coves/tasks/generate/airflow_generators/fivetran.py
@@ -65,7 +65,9 @@ class FivetranGenerator(BaseDbtCovesTaskGenerator):
             tasks[conn_id] = {
                 "trigger": {
                     "name": trigger_id,
-                    "call": self.generate_task(trigger_id, "FivetranOperator", **trigger_kwargs),
+                    "call": self.generate_task(
+                        trigger_id, "FivetranOperator", **trigger_kwargs
+                    ),
                 }
             }
             if not self.wait_for_completion:
@@ -79,7 +81,9 @@ class FivetranGenerator(BaseDbtCovesTaskGenerator):
                 }
                 tasks[conn_id]["sensor"] = {
                     "name": sensor_id,
-                    "call": self.generate_task(sensor_id, "FivetranSensor", **sensor_kwargs),
+                    "call": self.generate_task(
+                        sensor_id, "FivetranSensor", **sensor_kwargs
+                    ),
                 }
 
         return tasks
@@ -87,14 +91,20 @@ class FivetranGenerator(BaseDbtCovesTaskGenerator):
     def _dbt_database_in_destination(self, fivetran_destination, dbt_database):
         return (
             dbt_database
-            == fivetran_destination.get("details").get("config", {}).get("database", "").lower()
+            == fivetran_destination.get("details")
+            .get("config", {})
+            .get("database", "")
+            .lower()
         )
 
     def _dbt_schema_table_in_connector(self, connector_schemas, dbt_schema, dbt_table):
         for schema_details in connector_schemas.values():
             if schema_details.get("name_in_destination", "").lower() == dbt_schema:
                 for table_details in schema_details.get("tables", {}).values():
-                    if table_details.get("name_in_destination", "").lower() == dbt_table:
+                    if (
+                        table_details.get("name_in_destination", "").lower()
+                        == dbt_table
+                    ):
                         return True
         return False
 
@@ -113,8 +123,12 @@ class FivetranGenerator(BaseDbtCovesTaskGenerator):
                 # match dbt source_db to Fivetran destination database
                 if self._dbt_database_in_destination(dest_dict, source_db.lower()):
                     # find the appropiate Connector from destination connectors)
-                    for connector_id, connector_data in dest_dict.get("connectors", {}).items():
-                        for schema_id, schema_data in connector_data.get("schemas", {}).items():
+                    for connector_id, connector_data in dest_dict.get(
+                        "connectors", {}
+                    ).items():
+                        for schema_id, schema_data in connector_data.get(
+                            "schemas", {}
+                        ).items():
                             if (
                                 self._dbt_schema_table_in_connector(
                                     {schema_id: schema_data},

--- a/dbt_coves/tasks/generate/base.py
+++ b/dbt_coves/tasks/generate/base.py
@@ -97,9 +97,13 @@ class BaseGenerateTask(BaseConfiguredTask):
             return selected_schemas
 
     def get_relations(self, filtered_schemas):
-        rel_name_selectors = [relation for relation in self.get_config_value("select_relations")]
+        rel_name_selectors = [
+            relation for relation in self.get_config_value("select_relations")
+        ]
 
-        rel_excludes = [relation for relation in self.get_config_value("exclude_relations")]
+        rel_excludes = [
+            relation for relation in self.get_config_value("exclude_relations")
+        ]
 
         rel_wildcard_selectors = []
 
@@ -137,7 +141,9 @@ class BaseGenerateTask(BaseConfiguredTask):
                     break
 
         rels = (
-            intersected_rels if rel_name_selectors and rel_name_selectors[0] else listed_relations
+            intersected_rels
+            if rel_name_selectors and rel_name_selectors[0]
+            else listed_relations
         )
 
         return rels
@@ -214,7 +220,9 @@ class BaseGenerateTask(BaseConfiguredTask):
     def get_config_value(self, key):
         return self.coves_config.integrated["generate"][self.args.task][key]
 
-    def render_templates(self, relation, columns, destination, options=None, json_cols=None):
+    def render_templates(
+        self, relation, columns, destination, options=None, json_cols=None
+    ):
         destination.parent.mkdir(parents=True, exist_ok=True)
         context = self.get_templates_context(relation, columns, json_cols)
         self.render_templates_with_context(context, destination, options)
@@ -324,7 +332,9 @@ class BaseGenerateTask(BaseConfiguredTask):
             current_yml = open_yaml(yml_path)
             if not current_yml:
                 # target yml path exists but it's empty -> recreate file
-                return self.create_property_file(template, context, yml_path, templates_folder)
+                return self.create_property_file(
+                    template, context, yml_path, templates_folder
+                )
             object_in_yml = self.new_object_exists_in_current_yml(
                 current_yml,
                 template,
@@ -375,7 +385,9 @@ class BaseGenerateTask(BaseConfiguredTask):
                     elif update_strategy == "recreate":
                         sel_action = "recreate"
                     else:
-                        console.print(f"Update strategy {update_strategy} not a valid option.")
+                        console.print(
+                            f"Update strategy {update_strategy} not a valid option."
+                        )
                         exit()
                 elif options[strategy_key_recreate_all]:
                     sel_action = "recreate"
@@ -433,8 +445,10 @@ class BaseGenerateTask(BaseConfiguredTask):
                     if action == "recreate":
                         current_yml[resource_type_key][idx] = new_object
                     if action == "update":
-                        current_yml[resource_type_key][idx] = self.update_object_properties(
-                            curr_obj, new_object, resource_type
+                        current_yml[resource_type_key][idx] = (
+                            self.update_object_properties(
+                                curr_obj, new_object, resource_type
+                            )
                         )
 
         # "{Model/Source} {name} created/recreated/updated on file {filepath}"
@@ -461,9 +475,9 @@ class BaseGenerateTask(BaseConfiguredTask):
                 # If column exists in A, update it's description
                 # and leave as-is to avoid overriding tests
                 for current_column in columns_a:
-                    if (current_column.get("name") == new_column.get("name")) and new_column.get(
-                        "description"
-                    ):
+                    if (
+                        current_column.get("name") == new_column.get("name")
+                    ) and new_column.get("description"):
                         current_column["description"] = new_column.get("description")
             else:
                 columns_a.append(new_column)
@@ -498,8 +512,12 @@ class BaseGenerateTask(BaseConfiguredTask):
 
     def raise_duplicate_relations(self, relations):
         if not self.no_prompt:
-            relation_names = [f"{rel.schema.lower()}.{rel.name.lower()}" for rel in relations]
-            duplicates = {rel for rel in relation_names if relation_names.count(rel) > 1}
+            relation_names = [
+                f"{rel.schema.lower()}.{rel.name.lower()}" for rel in relations
+            ]
+            duplicates = {
+                rel for rel in relation_names if relation_names.count(rel) > 1
+            }
             if duplicates:
                 raise BaseGeneratorException(
                     "Can't select multiple relations with the exact same name: "

--- a/dbt_coves/tasks/generate/docs.py
+++ b/dbt_coves/tasks/generate/docs.py
@@ -91,7 +91,9 @@ class GenerateDocsTask(BaseConfiguredTask):
             with open(catalog_path, "r") as f:
                 return json.load(f)
         except FileNotFoundError:
-            raise DbtCovesGenerateDocsException(f"Catalog.json not found at {catalog_path}")
+            raise DbtCovesGenerateDocsException(
+                f"Catalog.json not found at {catalog_path}"
+            )
 
     def _merge_catalogs(
         self, local_catalog: Dict[str, Any], target_catalog: Dict[str, Any]

--- a/dbt_coves/tasks/generate/main.py
+++ b/dbt_coves/tasks/generate/main.py
@@ -38,7 +38,9 @@ class GenerateTask(BaseConfiguredTask):
              metadata for tables (used as input for sources and properties)""",
         )
         gen_subparser.set_defaults(cls=cls, which="generate")
-        sub_parsers = gen_subparser.add_subparsers(title="dbt-coves generate commands", dest="task")
+        sub_parsers = gen_subparser.add_subparsers(
+            title="dbt-coves generate commands", dest="task"
+        )
 
         # Register a separate sub parser for each sub task.
         [x.register_parser(sub_parsers, base_subparser) for x in cls.tasks]

--- a/dbt_coves/tasks/generate/metadata.py
+++ b/dbt_coves/tasks/generate/metadata.py
@@ -87,7 +87,8 @@ class GenerateMetadataTask(BaseGenerateTask):
             selected_rels = questionary.checkbox(
                 "Which metadata files would you like to generate?",
                 choices=[
-                    Choice(f"[{rel.schema}] {rel.name}", checked=True, value=rel) for rel in rels
+                    Choice(f"[{rel.schema}] {rel.name}", checked=True, value=rel)
+                    for rel in rels
                 ],
             ).ask()
 
@@ -133,7 +134,9 @@ class GenerateMetadataTask(BaseGenerateTask):
 
         return results
 
-    def generate_or_append_metadata(self, relation, destination, options, action, existing_rows):
+    def generate_or_append_metadata(
+        self, relation, destination, options, action, existing_rows
+    ):
         destination.parent.mkdir(parents=True, exist_ok=True)
         if action == "append":
             python_fs_action = "a"
@@ -182,7 +185,9 @@ class GenerateMetadataTask(BaseGenerateTask):
                     nested_key_names = list(json.loads(value[0]).keys())
                     result[json_col] = {}
                     for key_name in nested_key_names:
-                        result[json_col][key_name] = self.get_default_metadata_item(key_name)
+                        result[json_col][key_name] = self.get_default_metadata_item(
+                            key_name
+                        )
                 except TypeError:
                     console.print(
                         f"Column {json_col} in relation {relation.name} contains invalid JSON.\n"
@@ -252,7 +257,9 @@ class GenerateMetadataTask(BaseGenerateTask):
             else:
                 action = "create"
 
-            self.generate_or_append_metadata(rel, csv_path, options, action, existing_rows)
+            self.generate_or_append_metadata(
+                rel, csv_path, options, action, existing_rows
+            )
             self.metadata_files_processed.add(csv_path)
 
     @trackable

--- a/dbt_coves/tasks/generate/properties.py
+++ b/dbt_coves/tasks/generate/properties.py
@@ -114,7 +114,9 @@ class GeneratePropertiesTask(BaseGenerateTask):
                 f"An error occurred listing your dbt models: \n {result.stdout or result.stderr}"
             )
         if "no nodes selected" in result.stdout.lower():
-            raise GeneratePropertiesException(f"{result.stdout}\nSelectors used: {user_selectors}")
+            raise GeneratePropertiesException(
+                f"{result.stdout}\nSelectors used: {user_selectors}"
+            )
 
         manifest_json_lines = filter(
             lambda i: len(i) > 0 and i[0] == "{", result.stdout.splitlines()
@@ -127,10 +129,14 @@ class GeneratePropertiesTask(BaseGenerateTask):
 
     def load_manifest_nodes(self):
         try:
-            with open(f"{self.config.project_root}/target/manifest.json", "r") as manifest:
+            with open(
+                f"{self.config.project_root}/target/manifest.json", "r"
+            ) as manifest:
                 return json.load(manifest)
         except FileNotFoundError:
-            raise GeneratePropertiesException("Could not find manifest.json in target/ folder")
+            raise GeneratePropertiesException(
+                "Could not find manifest.json in target/ folder"
+            )
 
     def get_config_value(self, key):
         return self.coves_config.integrated["generate"]["properties"].get(key)
@@ -175,7 +181,9 @@ class GeneratePropertiesTask(BaseGenerateTask):
             relation = self.adapter.get_relation(database, schema, table)
             if relation:
                 columns = self.adapter.get_columns_in_relation(relation)
-                model_destination = self.render_path_template(prop_destination, model, manifest)
+                model_destination = self.render_path_template(
+                    prop_destination, model, manifest
+                )
                 model_path = Path(self.config.project_root).joinpath(model_destination)
 
                 self.render_templates(relation, columns, model_path, options)

--- a/dbt_coves/tasks/generate/sources.py
+++ b/dbt_coves/tasks/generate/sources.py
@@ -88,7 +88,8 @@ class GenerateSourcesTask(BaseGenerateTask):
             "--flatten-json-fields",
             type=str,
             choices=["yes", "no", "ask"],
-            help="Action to perform when JSON fields exist:" "'yes', 'no', 'ask' (per file)",
+            help="Action to perform when JSON fields exist:"
+            "'yes', 'no', 'ask' (per file)",
         )
         subparser.add_argument(
             "--overwrite-staging-models",
@@ -126,7 +127,8 @@ class GenerateSourcesTask(BaseGenerateTask):
             selected_rels = questionary.checkbox(
                 "Which sources would you like to generate?",
                 choices=[
-                    Choice(f"[{rel.schema}] {rel.name}", checked=True, value=rel) for rel in rels
+                    Choice(f"[{rel.schema}] {rel.name}", checked=True, value=rel)
+                    for rel in rels
                 ],
             ).ask()
 
@@ -332,7 +334,9 @@ class GenerateSourcesTask(BaseGenerateTask):
                     nested_key_names = list(json.loads(value[0]).keys())
                     result[json_col] = {}
                     for key_name in nested_key_names:
-                        result[json_col][key_name] = self.get_default_metadata_item(key_name)
+                        result[json_col][key_name] = self.get_default_metadata_item(
+                            key_name
+                        )
                     self.add_metadata_to_nested(relation, result, json_col)
                 except TypeError:
                     console.print(

--- a/dbt_coves/tasks/generate/templates.py
+++ b/dbt_coves/tasks/generate/templates.py
@@ -31,7 +31,9 @@ class GenerateTemplatesTask(BaseConfiguredTask):
         subparser.set_defaults(cls=cls, which="templates")
         return subparser
 
-    def copy_template_file(self, template_name, dbtcoves_template_path, destination_template_path):
+    def copy_template_file(
+        self, template_name, dbtcoves_template_path, destination_template_path
+    ):
         try:
             shutil.copyfile(dbtcoves_template_path, destination_template_path)
             console.print(f"Generated [green]{destination_template_path}[/green]")
@@ -47,7 +49,9 @@ class GenerateTemplatesTask(BaseConfiguredTask):
 
         dbt_project_path = self.config.project_root
         templates_destination_path = (
-            dbt_project_path / Path(self.coves_config.DBT_COVES_CONFIG_FOLDER) / "templates"
+            dbt_project_path
+            / Path(self.coves_config.DBT_COVES_CONFIG_FOLDER)
+            / "templates"
         )
         templates_destination_path.mkdir(parents=True, exist_ok=True)
 
@@ -57,7 +61,9 @@ class GenerateTemplatesTask(BaseConfiguredTask):
             target_destination = templates_destination_path / template_name
             if target_destination.exists():
                 if not options["overwrite_all"]:
-                    console.print(f"[yellow]{target_destination}[/yellow] already exists.")
+                    console.print(
+                        f"[yellow]{target_destination}[/yellow] already exists."
+                    )
                     overwrite = questionary.select(
                         "Would you like to overwrite it?",
                         choices=["No", "Yes", "Overwrite all", "Cancel"],
@@ -69,6 +75,8 @@ class GenerateTemplatesTask(BaseConfiguredTask):
                     if overwrite == "Cancel":
                         exit()
 
-            self.copy_template_file(template_name, dbtcoves_template_path, target_destination)
+            self.copy_template_file(
+                template_name, dbtcoves_template_path, target_destination
+            )
 
         return 0

--- a/dbt_coves/tasks/load/airbyte.py
+++ b/dbt_coves/tasks/load/airbyte.py
@@ -64,12 +64,18 @@ class LoadAirbyteTask(BaseLoadTask):
             type=str,
             help="Secret credentials provider, i.e. 'datacoves'",
         )
-        subparser.add_argument("--secrets-url", type=str, help="Secret credentials provider url")
+        subparser.add_argument(
+            "--secrets-url", type=str, help="Secret credentials provider url"
+        )
         subparser.add_argument(
             "--secrets-token", type=str, help="Secret credentials provider token"
         )
-        subparser.add_argument("--secrets-environment", type=str, help="Secret credentials project")
-        subparser.add_argument("--secrets-tags", type=str, help="Secret credentials tags")
+        subparser.add_argument(
+            "--secrets-environment", type=str, help="Secret credentials project"
+        )
+        subparser.add_argument(
+            "--secrets-tags", type=str, help="Secret credentials tags"
+        )
         subparser.add_argument("--secrets-key", type=str, help="Secret credentials key")
         subparser.set_defaults(cls=cls, which="airbyte")
         return subparser
@@ -120,13 +126,19 @@ class LoadAirbyteTask(BaseLoadTask):
             api_key=self.airbyte_api_key or None,
         )
 
-        console.print(f"Loading DBT Sources into Airbyte from {os.path.abspath(path)}\n")
+        console.print(
+            f"Loading DBT Sources into Airbyte from {os.path.abspath(path)}\n"
+        )
 
-        extracted_sources = self.retrieve_all_jsons_from_path(self.sources_load_destination)
+        extracted_sources = self.retrieve_all_jsons_from_path(
+            self.sources_load_destination
+        )
         extracted_destinations = self.retrieve_all_jsons_from_path(
             self.destinations_load_destination
         )
-        extracted_connections = self.retrieve_all_jsons_from_path(self.connections_load_destination)
+        extracted_connections = self.retrieve_all_jsons_from_path(
+            self.connections_load_destination
+        )
         for source in extracted_sources:
             self._create_or_update_source(source)
         for destination in extracted_destinations:
@@ -264,7 +276,9 @@ class LoadAirbyteTask(BaseLoadTask):
                 f"Connection test for {exported_data['name']} failed:\n "
                 f"{conn_status.get('message', '')}"
             )
-            update = questionary.confirm("Would you like to continue updating it?").ask()
+            update = questionary.confirm(
+                "Would you like to continue updating it?"
+            ).ask()
         if update:
             update_body = {
                 "name": exported_data["name"],
@@ -293,7 +307,9 @@ class LoadAirbyteTask(BaseLoadTask):
                 f"Connection test for {exported_data['name']} failed:\n "
                 f"{conn_status.get('message', '')}"
             )
-            create = questionary.confirm("Would you like to continue creating it?").ask()
+            create = questionary.confirm(
+                "Would you like to continue creating it?"
+            ).ask()
 
         if create:
             if object_type == "sources":
@@ -396,7 +412,9 @@ class LoadAirbyteTask(BaseLoadTask):
     def _update_destination(self, exported_data, destination_id):
         exported_data.pop("connectorVersion", None)
         exported_data = self._get_secrets(exported_data, "destinations")
-        self._update_source_or_destination(exported_data, "destinations", destination_id)
+        self._update_source_or_destination(
+            exported_data, "destinations", destination_id
+        )
 
     def _destinations_are_equivalent(self, exported_destination, current_destination):
         current_copy = copy(current_destination)
@@ -494,15 +512,15 @@ class LoadAirbyteTask(BaseLoadTask):
                 schedule["cronExpression"] = schedule_data.get("cron", {}).get(
                     "cronExpression"
                 ) or schedule_data.get("basicSchedule", {}).get("cronExpression")
-            connection["schedule"] = {k: v for k, v in schedule.items() if v is not None}
+            connection["schedule"] = {
+                k: v for k, v in schedule.items() if v is not None
+            }
         return connection
 
     def _create_connection(self, exported_json_data, source_id, destination_id):
         exported_json_data["sourceId"] = source_id
         exported_json_data["destinationId"] = destination_id
-        connection_name = (
-            f"{exported_json_data['sourceName']}-{exported_json_data['destinationName']}"
-        )
+        connection_name = f"{exported_json_data['sourceName']}-{exported_json_data['destinationName']}"
         exported_json_data.pop("sourceName", None)
         exported_json_data.pop("destinationName", None)
         exported_json_data.pop("operationIds", None)
@@ -516,13 +534,17 @@ class LoadAirbyteTask(BaseLoadTask):
                 self.airbyte_api.connections_list.append(response)
                 return connection_name
         except AirbyteApiCallerException as ex:
-            raise AirbyteApiCallerException(f"Could not create Airbyte connection: {ex}")
+            raise AirbyteApiCallerException(
+                f"Could not create Airbyte connection: {ex}"
+            )
 
     def _delete_connection(self, connection_id):
         try:
             self.airbyte_api.delete_connection(connection_id)
         except AirbyteApiCallerException:
-            raise AirbyteLoaderException("Could not delete Airbyte connection for re-creation")
+            raise AirbyteLoaderException(
+                "Could not delete Airbyte connection for re-creation"
+            )
 
     def _get_source_id_by_name(self, source_name):
         for source in self.airbyte_api.sources_list:
@@ -583,10 +605,14 @@ class LoadAirbyteTask(BaseLoadTask):
             else:
                 connection_id = connection["connectionId"]
                 self._delete_connection(connection_id)
-                conn_name = self._create_connection(connection_json, source_id, destination_id)
+                conn_name = self._create_connection(
+                    connection_json, source_id, destination_id
+                )
                 self._add_update_result("connections", conn_name)
         else:
-            conn_name = self._create_connection(connection_json, source_id, destination_id)
+            conn_name = self._create_connection(
+                connection_json, source_id, destination_id
+            )
             self.loading_results["connections"]["created"].append(conn_name)
 
     def _add_update_result(self, obj_type, obj_name):
@@ -602,7 +628,9 @@ class LoadAirbyteTask(BaseLoadTask):
                 object_definition = self._get_source_definition_by_type(source_type)
             else:
                 destination_type = exported_json_data.get("destinationType", "")
-                object_definition = self._get_destination_definition_by_type(destination_type)
+                object_definition = self._get_destination_definition_by_type(
+                    destination_type
+                )
         except AirbyteLoaderException:
             return
 

--- a/dbt_coves/tasks/load/fivetran.py
+++ b/dbt_coves/tasks/load/fivetran.py
@@ -51,14 +51,22 @@ class LoadFivetranTask(BaseLoadTask):
             help="Secret files location for Fivetran configuration, i.e. './secrets'",
         )
         subparser.add_argument(
-            "--secrets-manager", type=str, help="Secret credentials provider, i.e. 'datacoves'"
+            "--secrets-manager",
+            type=str,
+            help="Secret credentials provider, i.e. 'datacoves'",
         )
-        subparser.add_argument("--secrets-url", type=str, help="Secret credentials provider url")
+        subparser.add_argument(
+            "--secrets-url", type=str, help="Secret credentials provider url"
+        )
         subparser.add_argument(
             "--secrets-token", type=str, help="Secret credentials provider token"
         )
-        subparser.add_argument("--secrets-environment", type=str, help="Secret credentials project")
-        subparser.add_argument("--secrets-tags", type=str, help="Secret credentials tags")
+        subparser.add_argument(
+            "--secrets-environment", type=str, help="Secret credentials project"
+        )
+        subparser.add_argument(
+            "--secrets-tags", type=str, help="Secret credentials tags"
+        )
         subparser.add_argument("--secrets-key", type=str, help="Secret credentials key")
         subparser.set_defaults(cls=cls, which="fivetran")
         return subparser
@@ -142,7 +150,9 @@ class LoadFivetranTask(BaseLoadTask):
         for fivetran_destination in self.extracted_destinations:
             if self.local_secrets:
                 self._load_fivetran_local_secrets(fivetran_destination)
-            elif self.secret_manager_data and self.secrets_manager.lower() == "datacoves":
+            elif (
+                self.secret_manager_data and self.secrets_manager.lower() == "datacoves"
+            ):
                 self._load_fivetran_datacoves_secrets(fivetran_destination)
 
             for destination_data in fivetran_destination.values():
@@ -158,7 +168,9 @@ class LoadFivetranTask(BaseLoadTask):
                 if target_group_id != exported_group_id:
                     self._update_group_id(fivetran_destination, target_group_id)
 
-                self._update_or_create_fivetran_destination(fivetran_destination, target_group_id)
+                self._update_or_create_fivetran_destination(
+                    fivetran_destination, target_group_id
+                )
         self._print_load_results()
 
         return 0
@@ -182,14 +194,16 @@ class LoadFivetranTask(BaseLoadTask):
         return FivetranApiCaller(api_key, api_secret)
 
     def _fivetran_destination_updated(self, destination_details):
-        current_destination = self.fivetran_api._get_destination_details(destination_details["id"])
+        current_destination = self.fivetran_api._get_destination_details(
+            destination_details["id"]
+        )
         return destination_details == current_destination
 
     def _update_fivetran_destination(self, destination_details):
         destination_id = destination_details["id"]
-        destination_name = self.fivetran_api.fivetran_groups[destination_details["group_id"]][
-            "name"
-        ]
+        destination_name = self.fivetran_api.fivetran_groups[
+            destination_details["group_id"]
+        ]["name"]
         if self._fivetran_destination_updated(destination_details):
             console.print(
                 f"Destination [green]{destination_details['id']}[/green] already up to date. "
@@ -205,24 +219,30 @@ class LoadFivetranTask(BaseLoadTask):
         del destination_details["id"]
         destination_details["run_setup_tests"] = False
         created_destination = self.fivetran_api.create_destination(destination_details)
-        destination_name = self.fivetran_api.fivetran_groups[created_destination["group_id"]][
-            "name"
-        ]
+        destination_name = self.fivetran_api.fivetran_groups[
+            created_destination["group_id"]
+        ]["name"]
         self.load_results["destinations"]["created"].add(destination_name)
         return created_destination
 
     def _fivetran_connector_updated(self, connector_details):
-        current_connector = self.fivetran_api._get_connector_details(connector_details["id"])
+        current_connector = self.fivetran_api._get_connector_details(
+            connector_details["id"]
+        )
         return connector_details == current_connector
 
     def _update_fivetran_connector(self, connector_details, group_name):
         connector_id = connector_details["id"]
         if self._fivetran_connector_updated(connector_details):
-            console.print(f"Connector [green]{connector_id}[/green] already up to date. Skipping")
+            console.print(
+                f"Connector [green]{connector_id}[/green] already up to date. Skipping"
+            )
             return connector_details
         connector_details["run_setup_tests"] = False
         self._fill_required_config_fields(connector_details, group_name)
-        updated_connector = self.fivetran_api.update_connector(connector_id, connector_details)
+        updated_connector = self.fivetran_api.update_connector(
+            connector_id, connector_details
+        )
         connector_schema = updated_connector["schema"]
         self.load_results["connectors"]["updated"].add(connector_schema)
         return updated_connector
@@ -240,7 +260,9 @@ class LoadFivetranTask(BaseLoadTask):
         connector_id = connector["id"]
         connector_schemas = self.fivetran_api._get_connector_schemas(connector_id)
         if connector_schemas:
-            self.fivetran_api.update_connector_schema_config(connector_id, extracted_schemas)
+            self.fivetran_api.update_connector_schema_config(
+                connector_id, extracted_schemas
+            )
             for extracted_schema in extracted_schemas.values():
                 schema_name_in_destination = extracted_schema["name_in_destination"]
                 self.load_results["schemas"]["updated"].add(schema_name_in_destination)
@@ -252,7 +274,9 @@ class LoadFivetranTask(BaseLoadTask):
                         table_name_in_destination,
                         table_config,
                     )
-                    self.load_results["tables"]["updated"].add(table_name_in_destination)
+                    self.load_results["tables"]["updated"].add(
+                        table_name_in_destination
+                    )
 
     def _get_existent_destination(self, target_group_id):
         for dest_data in self.fivetran_api.fivetran_data.values():
@@ -281,7 +305,9 @@ class LoadFivetranTask(BaseLoadTask):
                     for k, v in secret.get("value", {}).items():
                         self._replace_dict_key(object_details, k, v)
 
-    def _update_or_create_fivetran_destination(self, exported_destination, target_group_id):
+    def _update_or_create_fivetran_destination(
+        self, exported_destination, target_group_id
+    ):
         """
         Given exported destination data
         - update if ID exists
@@ -312,12 +338,18 @@ class LoadFivetranTask(BaseLoadTask):
                     exported_connector_details, group_name
                 )
             else:
-                self._fill_required_config_fields(exported_connector_details, group_name)
-                target_connector = self._create_fivetran_connector(exported_connector_details)
+                self._fill_required_config_fields(
+                    exported_connector_details, group_name
+                )
+                target_connector = self._create_fivetran_connector(
+                    exported_connector_details
+                )
 
             exported_schemas = exported_connector.get("schemas", {})
             if exported_schemas:
-                self._update_target_connector_schema_config(target_connector, exported_schemas)
+                self._update_target_connector_schema_config(
+                    target_connector, exported_schemas
+                )
 
     def _fill_required_config_fields(self, connector_details, group_name):
         """
@@ -328,7 +360,9 @@ class LoadFivetranTask(BaseLoadTask):
         """
         service_type = connector_details["service"]
         connector_config = connector_details["config"]
-        required_config_fields = self.fivetran_api.get_service_required_fields(service_type)
+        required_config_fields = self.fivetran_api.get_service_required_fields(
+            service_type
+        )
         for field in required_config_fields:
             if not connector_config.get(field):
                 connector_config[field] = questionary.text(
@@ -343,7 +377,9 @@ class LoadFivetranTask(BaseLoadTask):
                     if report_field in connector_config:
                         del connector_config[report_field]
 
-    def _exported_connector_exists_in_destination(self, exported_connector, existent_destination):
+    def _exported_connector_exists_in_destination(
+        self, exported_connector, existent_destination
+    ):
         exported_connector_name = exported_connector["schema"]
         for existent_connector in existent_destination.get("connectors", {}).values():
             if existent_connector["details"]["schema"] == exported_connector_name:
@@ -378,7 +414,9 @@ class LoadFivetranTask(BaseLoadTask):
             if service_type == group_data.get("service", ""):
                 group_candidates_ids.add(existent_group_id)
 
-        console.print(f"Extracted Fivetran group with ID [red]{group_id}[/red] not found.")
+        console.print(
+            f"Extracted Fivetran group with ID [red]{group_id}[/red] not found."
+        )
 
         # Path 2: get destination with the same Service type
         if group_candidates_ids:

--- a/dbt_coves/tasks/load/main.py
+++ b/dbt_coves/tasks/load/main.py
@@ -23,7 +23,9 @@ class LoadTask(BaseConfiguredTask):
             help="Loads configurations into different systems, such as Airbyte.",
         )
         ext_subparser.set_defaults(cls=cls, which="load")
-        sub_parsers = ext_subparser.add_subparsers(title="dbt-coves load commands", dest="task")
+        sub_parsers = ext_subparser.add_subparsers(
+            title="dbt-coves load commands", dest="task"
+        )
         LoadAirbyteTask.register_parser(sub_parsers, base_subparser)
         LoadFivetranTask.register_parser(sub_parsers, base_subparser)
         cls.arg_parser = ext_subparser

--- a/dbt_coves/tasks/setup/main.py
+++ b/dbt_coves/tasks/setup/main.py
@@ -71,7 +71,11 @@ class SetupTask(NonDbtBaseTask):
 
     @trackable
     def run(self) -> int:
-        from dbt_coves import __dbt_major_version__, __dbt_minor_version__, __dbt_patch_version__
+        from dbt_coves import (
+            __dbt_major_version__,
+            __dbt_minor_version__,
+            __dbt_patch_version__,
+        )
 
         self.repo_path = os.environ.get("DATACOVES__REPO_PATH", Path().resolve())
         self.copier_context = {"no_prompt": self.get_config_value("no_prompt")}
@@ -96,7 +100,9 @@ class SetupTask(NonDbtBaseTask):
         )
         if dbt_checkpoint_version:
             os.environ["DATACOVES__DBT_CHECKPOINT_VERSION"] = dbt_checkpoint_version
-        yamllint_version = self._get_latest_repo_tag(THIRD_PARTY_PRECOMMIT_REPOS["yamllint"])
+        yamllint_version = self._get_latest_repo_tag(
+            THIRD_PARTY_PRECOMMIT_REPOS["yamllint"]
+        )
         if yamllint_version:
             os.environ["DATACOVES__YAMLLINT_VERSION"] = yamllint_version
         self.copier_context["datacoves_env_version"] = os.environ.get(

--- a/dbt_coves/tasks/setup/utils.py
+++ b/dbt_coves/tasks/setup/utils.py
@@ -50,7 +50,8 @@ def get_dbt_projects(path=os.getcwd()):
     for file in Path(path).rglob("dbt_project.yml"):
         file_str = str(file)
         if all(
-            folder not in file_str for folder in ["dbt_packages", "compiled", "target", "macros"]
+            folder not in file_str
+            for folder in ["dbt_packages", "compiled", "target", "macros"]
         ):
             project_name = open_yaml(file)["name"]
             project_path = str(file.relative_to(path).parent)

--- a/dbt_coves/ui/traceback.py
+++ b/dbt_coves/ui/traceback.py
@@ -27,7 +27,9 @@ class DbtCovesTraceback:
             display_link=True,
             lines_before=5,
             lines_after=2,
-            line_color=pretty_errors.RED + "> " + pretty_errors.default_config.line_color,
+            line_color=pretty_errors.RED
+            + "> "
+            + pretty_errors.default_config.line_color,
             code_color="  " + pretty_errors.default_config.line_color,
             truncate_code=True,
             display_locals=True,

--- a/dbt_coves/utils/api_caller.py
+++ b/dbt_coves/utils/api_caller.py
@@ -15,7 +15,8 @@ FIVETRAN_API_ENDPOINTS = {
     "DESTINATION_LIST": FIVETRAN_API_BASE_URL + "/groups",
     "DESTINATION_DETAILS": FIVETRAN_API_BASE_URL + "/destinations/{destination}",
     "DESTINATION_CREATE": FIVETRAN_API_BASE_URL + "/destinations",
-    "CONNECTOR_DESTINATION_LIST": FIVETRAN_API_BASE_URL + "/groups/{destination}/connectors",
+    "CONNECTOR_DESTINATION_LIST": FIVETRAN_API_BASE_URL
+    + "/groups/{destination}/connectors",
     "CONNECTOR_CREATE": FIVETRAN_API_BASE_URL + "/connectors/",
     "CONNECTOR_DETAILS": FIVETRAN_API_BASE_URL + "/connectors/{connector}",
     "CONNECTOR_SCHEMAS": FIVETRAN_API_BASE_URL + "/connectors/{connector}/schemas",
@@ -33,7 +34,9 @@ def api_call(
     auth=None,
 ):
     """Generic `api caller`"""
-    response = requests.request(method, url=endpoint, json=body, headers=headers, auth=auth)
+    response = requests.request(
+        method, url=endpoint, json=body, headers=headers, auth=auth
+    )
     try:
         if response.status_code == 404:
             return {}
@@ -77,9 +80,13 @@ class AirbyteApiCaller:
             if not workspaces:
                 raise AirbyteApiCallerException("No Airbyte workspaces found")
             self.workspace_id = workspaces[0]["workspaceId"]
-            self.connections_list = self._get_all("connections", workspaceIds=self.workspace_id)
+            self.connections_list = self._get_all(
+                "connections", workspaceIds=self.workspace_id
+            )
             self.sources_list = self._get_all("sources", workspaceIds=self.workspace_id)
-            self.destinations_list = self._get_all("destinations", workspaceIds=self.workspace_id)
+            self.destinations_list = self._get_all(
+                "destinations", workspaceIds=self.workspace_id
+            )
         except AirbyteApiCallerException as e:
             raise AirbyteApiCallerException(
                 f"Couldn't retrieve Airbyte connections, sources and destinations: {e}"
@@ -89,7 +96,12 @@ class AirbyteApiCaller:
     def _request(self, method, path, body=None, params=None, timeout=None):
         url = f"{self.base_url}/{path.lstrip('/')}"
         response = requests.request(
-            method, url=url, json=body, params=params, headers=self.headers, timeout=timeout
+            method,
+            url=url,
+            json=body,
+            params=params,
+            headers=self.headers,
+            timeout=timeout,
         )
         if response.status_code == 204:
             return None
@@ -147,14 +159,18 @@ class AirbyteApiCaller:
     def get_source_spec(self, definition_id):
         """Fetch connector spec (including airbyte_secret markers) for a source definition."""
         try:
-            return self._request("GET", f"connector_definitions/sources/{definition_id}")
+            return self._request(
+                "GET", f"connector_definitions/sources/{definition_id}"
+            )
         except AirbyteApiCallerException:
             return None
 
     def get_destination_spec(self, definition_id):
         """Fetch connector spec for a destination definition."""
         try:
-            return self._request("GET", f"connector_definitions/destinations/{definition_id}")
+            return self._request(
+                "GET", f"connector_definitions/destinations/{definition_id}"
+            )
         except AirbyteApiCallerException:
             return None
 
@@ -182,7 +198,9 @@ class AirbyteApiCaller:
         self._request("DELETE", f"destinations/{destination_id}")
 
     def check_destination(self, destination_id, timeout=None):
-        return self._request("POST", f"destinations/{destination_id}/check", timeout=timeout)
+        return self._request(
+            "POST", f"destinations/{destination_id}/check", timeout=timeout
+        )
 
     # Connection CRUD
     def create_connection(self, body):
@@ -222,7 +240,9 @@ class FivetranApiCaller:
         """
         destination_details = self._fivetran_api_call(
             "GET",
-            FIVETRAN_API_ENDPOINTS["DESTINATION_DETAILS"].format(destination=destination_id),
+            FIVETRAN_API_ENDPOINTS["DESTINATION_DETAILS"].format(
+                destination=destination_id
+            ),
         )
         return destination_details.get("data")
 
@@ -252,14 +272,20 @@ class FivetranApiCaller:
         """
         destination_connectors = self._fivetran_api_call(
             "GET",
-            FIVETRAN_API_ENDPOINTS["CONNECTOR_DESTINATION_LIST"].format(destination=destination_id),
+            FIVETRAN_API_ENDPOINTS["CONNECTOR_DESTINATION_LIST"].format(
+                destination=destination_id
+            ),
         )
         connector_data = {}
         for connector in destination_connectors.get("data", {}).get("items", []):
             connector_id = connector["id"]
             connector_data[connector_id] = {}
-            connector_data[connector_id]["details"] = self._get_connector_details(connector_id)
-            connector_data[connector_id]["schemas"] = self._get_connector_schemas(connector_id)
+            connector_data[connector_id]["details"] = self._get_connector_details(
+                connector_id
+            )
+            connector_data[connector_id]["schemas"] = self._get_connector_schemas(
+                connector_id
+            )
         return connector_data
 
     def create_group(self, group_name, service) -> str:
@@ -293,7 +319,9 @@ class FivetranApiCaller:
                     "service", ""
                 )
                 destination_data["details"] = destination_details
-                destination_data["connectors"] = self._get_destination_connectors(destination_id)
+                destination_data["connectors"] = self._get_destination_connectors(
+                    destination_id
+                )
                 fivetran_data[destination_id] = destination_data
         self.fivetran_groups = fivetran_group_map
         return fivetran_data
@@ -301,7 +329,9 @@ class FivetranApiCaller:
     def update_destination(self, destination_id, destination_details):
         destination = self._fivetran_api_call(
             "PATCH",
-            FIVETRAN_API_ENDPOINTS["DESTINATION_DETAILS"].format(destination=destination_id),
+            FIVETRAN_API_ENDPOINTS["DESTINATION_DETAILS"].format(
+                destination=destination_id
+            ),
             destination_details,
         )
         return destination["data"]

--- a/dbt_coves/utils/flags.py
+++ b/dbt_coves/utils/flags.py
@@ -134,7 +134,12 @@ class DbtCovesFlags:
             "current-dir": False,
         }
         self.setup = {"no_prompt": False, "template_url": None, "update": False}
-        self.dbt = {"command": None, "project_dir": None, "virtualenv": None, "cleanup": False}
+        self.dbt = {
+            "command": None,
+            "project_dir": None,
+            "virtualenv": None,
+            "cleanup": False,
+        }
         self.data_sync = {"redshift": {"tables": []}, "snowflake": {"tables": []}}
         self.blue_green = {
             "prod_db_env_var": None,
@@ -207,20 +212,29 @@ class DbtCovesFlags:
                     self.generate["sources"]["database"] = self.args.database
                 if self.args.select_relations:
                     self.generate["sources"]["select_relations"] = [
-                        relation.strip() for relation in self.args.select_relations.split(",")
+                        relation.strip()
+                        for relation in self.args.select_relations.split(",")
                     ]
                 if self.args.sources_destination:
-                    self.generate["sources"]["sources_destination"] = self.args.sources_destination
+                    self.generate["sources"]["sources_destination"] = (
+                        self.args.sources_destination
+                    )
                 if self.args.models_destination:
-                    self.generate["sources"]["models_destination"] = self.args.models_destination
+                    self.generate["sources"]["models_destination"] = (
+                        self.args.models_destination
+                    )
                 if self.args.model_props_destination:
-                    self.generate["sources"][
-                        "model_props_destination"
-                    ] = self.args.model_props_destination
+                    self.generate["sources"]["model_props_destination"] = (
+                        self.args.model_props_destination
+                    )
                 if self.args.update_strategy:
-                    self.generate["sources"]["update_strategy"] = self.args.update_strategy
+                    self.generate["sources"]["update_strategy"] = (
+                        self.args.update_strategy
+                    )
                 if self.args.templates_folder:
-                    self.generate["sources"]["templates_folder"] = self.args.templates_folder
+                    self.generate["sources"]["templates_folder"] = (
+                        self.args.templates_folder
+                    )
                 if self.args.metadata:
                     self.generate["sources"]["metadata"] = self.args.metadata
                 if self.args.exclude_relations:
@@ -230,9 +244,9 @@ class DbtCovesFlags:
                 if self.args.no_prompt:
                     self.generate["sources"]["no_prompt"] = True
                 if self.args.flatten_json_fields:
-                    self.generate["sources"][
-                        "flatten_json_fields"
-                    ] = self.args.flatten_json_fields.lower()
+                    self.generate["sources"]["flatten_json_fields"] = (
+                        self.args.flatten_json_fields.lower()
+                    )
                 if self.args.overwrite_staging_models:
                     self.generate["sources"]["overwrite_staging_models"] = True
                 if self.args.skip_model_props:
@@ -241,13 +255,17 @@ class DbtCovesFlags:
             # generate properties
             if self.args.cls.__name__ == "GeneratePropertiesTask":
                 if self.args.templates_folder:
-                    self.generate["properties"]["templates_folder"] = self.args.templates_folder
+                    self.generate["properties"]["templates_folder"] = (
+                        self.args.templates_folder
+                    )
                 if self.args.metadata:
                     self.generate["properties"]["metadata"] = self.args.metadata
                 if self.args.destination:
                     self.generate["properties"]["destination"] = self.args.destination
                 if self.args.update_strategy:
-                    self.generate["sources"]["update_strategy"] = self.args.update_strategy
+                    self.generate["sources"]["update_strategy"] = (
+                        self.args.update_strategy
+                    )
                 if self.args.select:
                     self.generate["properties"]["select"] = self.args.select
                 if self.args.exclude:
@@ -267,11 +285,13 @@ class DbtCovesFlags:
                     ]
                 if self.args.select_relations:
                     self.generate["metadata"]["select_relations"] = [
-                        relation.strip() for relation in self.args.select_relations.split(",")
+                        relation.strip()
+                        for relation in self.args.select_relations.split(",")
                     ]
                 if self.args.exclude_relations:
                     self.generate["metadata"]["exclude_relations"] = [
-                        relation.strip() for relation in self.args.exclude_relations.split(",")
+                        relation.strip()
+                        for relation in self.args.exclude_relations.split(",")
                     ]
                 if self.args.destination:
                     self.generate["metadata"]["destination"] = self.args.destination
@@ -294,27 +314,39 @@ class DbtCovesFlags:
                 if self.args.dags_path:
                     self.generate["airflow_dags"]["dags_path"] = self.args.dags_path
                 if self.args.validate_operators:
-                    self.generate["airflow_dags"][
-                        "validate_operators"
-                    ] = self.args.validate_operators
+                    self.generate["airflow_dags"]["validate_operators"] = (
+                        self.args.validate_operators
+                    )
                 if self.args.generators_folder:
-                    self.generate["airflow_dags"]["generators_folder"] = self.args.generators_folder
+                    self.generate["airflow_dags"]["generators_folder"] = (
+                        self.args.generators_folder
+                    )
                 if self.args.generators_params:
-                    self.generate["airflow_dags"]["generators_params"] = self.args.generators_params
+                    self.generate["airflow_dags"]["generators_params"] = (
+                        self.args.generators_params
+                    )
                 if self.args.secrets_path:
-                    self.generate["airflow_dags"]["secrets_path"] = self.args.secrets_path
+                    self.generate["airflow_dags"]["secrets_path"] = (
+                        self.args.secrets_path
+                    )
                 if self.args.secrets_manager:
-                    self.generate["airflow_dags"]["secrets_manager"] = self.args.secrets_manager
+                    self.generate["airflow_dags"]["secrets_manager"] = (
+                        self.args.secrets_manager
+                    )
                 if self.args.secrets_url:
                     self.generate["airflow_dags"]["secrets_url"] = self.args.secrets_url
                 if self.args.secrets_token:
-                    self.generate["airflow_dags"]["secrets_token"] = self.args.secrets_token
+                    self.generate["airflow_dags"]["secrets_token"] = (
+                        self.args.secrets_token
+                    )
                 if self.args.secrets_environment:
-                    self.generate["airflow_dags"][
-                        "secrets_environment"
-                    ] = self.args.secrets_environment
+                    self.generate["airflow_dags"]["secrets_environment"] = (
+                        self.args.secrets_environment
+                    )
                 if self.args.secrets_tags:
-                    self.generate["airflow_dags"]["secrets_tags"] = self.args.secrets_tags
+                    self.generate["airflow_dags"]["secrets_tags"] = (
+                        self.args.secrets_tags
+                    )
                 if self.args.secrets_key:
                     self.generate["airflow_dags"]["secrets_key"] = self.args.secrets_key
 
@@ -335,7 +367,9 @@ class DbtCovesFlags:
                 if self.args.secrets_token:
                     self.load["airbyte"]["secrets_token"] = self.args.secrets_token
                 if self.args.secrets_environment:
-                    self.load["airbyte"]["secrets_environment"] = self.args.secrets_environment
+                    self.load["airbyte"]["secrets_environment"] = (
+                        self.args.secrets_environment
+                    )
                 if self.args.secrets_tags:
                     self.load["airbyte"]["secrets_tags"] = [
                         tag.strip() for tag in self.args.secrets_tags.split(",")
@@ -362,7 +396,9 @@ class DbtCovesFlags:
                 if self.args.secrets_token:
                     self.load["fivetran"]["secrets_token"] = self.args.secrets_token
                 if self.args.secrets_environment:
-                    self.load["fivetran"]["secrets_environment"] = self.args.secrets_environment
+                    self.load["fivetran"]["secrets_environment"] = (
+                        self.args.secrets_environment
+                    )
                 if self.args.secrets_tags:
                     self.load["fivetran"]["secrets_tags"] = [
                         tag.strip() for tag in self.args.secrets_tags.split(",")
@@ -432,7 +468,9 @@ class DbtCovesFlags:
                 if self.args.staging_suffix:
                     self.blue_green["staging_suffix"] = self.args.staging_suffix
                 if self.args.drop_staging_db_at_start:
-                    self.blue_green["drop_staging_db_at_start"] = self.args.drop_staging_db_at_start
+                    self.blue_green["drop_staging_db_at_start"] = (
+                        self.args.drop_staging_db_at_start
+                    )
                 if self.args.drop_staging_db_on_failure:
                     self.blue_green["drop_staging_db_on_failure"] = (
                         self.args.drop_staging_db_on_failure

--- a/dbt_coves/utils/jinja.py
+++ b/dbt_coves/utils/jinja.py
@@ -8,9 +8,13 @@ def add_env_vars(context):
     return context
 
 
-def render_template_file(name, context, output_path, templates_folder=".dbt_coves/templates"):
+def render_template_file(
+    name, context, output_path, templates_folder=".dbt_coves/templates"
+):
     context_with_env_vars = add_env_vars(context)
-    output = get_render_output(name, context_with_env_vars, templates_folder=templates_folder)
+    output = get_render_output(
+        name, context_with_env_vars, templates_folder=templates_folder
+    )
 
     with open(output_path, "w") as rendered:
         rendered.write(output)
@@ -26,7 +30,9 @@ def render_template(template_content, context):
 
 def get_render_output(name, context, templates_folder=".dbt_coves/templates"):
     env = Environment(
-        loader=ChoiceLoader([FileSystemLoader(templates_folder), PackageLoader("dbt_coves")]),
+        loader=ChoiceLoader(
+            [FileSystemLoader(templates_folder), PackageLoader("dbt_coves")]
+        ),
         keep_trailing_newline=True,
     )
     template = env.get_template(name)

--- a/dbt_coves/utils/secrets.py
+++ b/dbt_coves/utils/secrets.py
@@ -13,12 +13,12 @@ def load_secret_manager_data(task_instance) -> dict:
     manager = task_instance.secrets_manager.lower()
     if manager == "datacoves":
         # Contact the secrets manager and retrieve Secrets
-        secrets_url = os.getenv("DATACOVES__SECRETS_URL") or task_instance.get_config_value(
-            "secrets_url"
-        )
-        secrets_token = os.getenv("DATACOVES__SECRETS_TOKEN") or task_instance.get_config_value(
-            "secrets_token"
-        )
+        secrets_url = os.getenv(
+            "DATACOVES__SECRETS_URL"
+        ) or task_instance.get_config_value("secrets_url")
+        secrets_token = os.getenv(
+            "DATACOVES__SECRETS_TOKEN"
+        ) or task_instance.get_config_value("secrets_token")
         secrets_environment = os.getenv(
             "DATACOVES__ENVIRONMENT_SLUG"
         ) or task_instance.get_config_value("secrets_environment")

--- a/dbt_coves/utils/shell.py
+++ b/dbt_coves/utils/shell.py
@@ -4,7 +4,9 @@ from subprocess import run as shell_run
 from typing import List, Optional, Sequence, Union
 
 
-def run(cmd, cwd: Optional[Union[str, Path]] = None, write_to_stdout: bool = True) -> Popen:
+def run(
+    cmd, cwd: Optional[Union[str, Path]] = None, write_to_stdout: bool = True
+) -> Popen:
     with Popen(cmd, stdout=PIPE, bufsize=1, universal_newlines=True, cwd=cwd) as proc:
         if write_to_stdout:
             for line in proc.stdout:

--- a/dbt_coves/utils/tracking.py
+++ b/dbt_coves/utils/tracking.py
@@ -21,7 +21,8 @@ def trackable(task, **kwargs):
     def wrapper(task_instance, **kwargs):
         exit_code = task(task_instance)
         if task_instance.args.uuid and not (
-            task_instance.args.disable_tracking or task_instance.coves_config.disable_tracking
+            task_instance.args.disable_tracking
+            or task_instance.coves_config.disable_tracking
         ):
             try:
                 task_execution_props = _gen_task_usage_props(task_instance, exit_code)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,21 +27,21 @@ dependencies = [
     "rich>=10.4",
     "Jinja2>2.11.2",
     "python-slugify<9.0.0",
-    "dbt-core>=1.1,<1.12",
+    "dbt-core>=1.1,<2.0",
     "ruamel-yaml>=0.17.21,<0.20",
     "db-dtypes>=1.0.5,<2",
     "copier>=9.0.0",
     "gitpython>=3.1.31,<4",
-    "mixpanel>=4.10.0,<5",
+    "mixpanel>=4.10.0,<6",
     "black>=25,<27",
     "isort>=5.12.0,<9",
     "dlt[redshift]>=1.0",
     "psycopg2-binary>=2.9.9,<3",
     "sqlalchemy>=1.4,<3",
     "enlighten>=1.12.4,<2",
-    "snowflake-connector-python>=3.12.1,<4.6",
+    "snowflake-connector-python>=3.12.1,<4.8",
     "jinja2-env>=0.1.3,<0.2",
-    "prompt-toolkit==3.0.51",
+    "prompt-toolkit==3.0.52",
 ]
 
 [project.urls]
@@ -58,32 +58,32 @@ dev = [
     "bumpversion>=0.6.0,<0.7",
     "pytest>=9.0.3,<10",
     "pytest-cov>=4.0.0,<8",
-    "mypy>=0.991,<2.2",
-    "towncrier>=22.12.0,<23",
+    "mypy>=0.991,<2.4",
+    "towncrier>=22.12.0,<26",
     "pytest-mock>=3.6.1,<4",
-    "pytest-sugar>=0.9.4,<0.10",
+    "pytest-sugar>=0.9.4,<1.2",
     "pytest-datafiles>=2.0,<4",
     "asciinema>=2.0.2,<3",
     "pytest-dictsdiff>=0.5.8,<0.6",
     "ipdb>=0.13.9,<0.14",
-    "sphinx-argparse>=0.4.0,<0.5",
+    "sphinx-argparse>=0.4.0,<0.7",
     "sphinxcontrib-restbuilder>=0.3,<0.4",
     "types-PyYAML>=5.4.1,<7",
     "types-python-slugify>=8.0.0.0,<9",
     "types-requests>=2.28.11.5,<3",
-    "flake8>=7.1.0,<8",
+    "ruff==0.15.19",
 ]
 test = [
-    "dbt-redshift>=1.1,<1.11",
-    "dbt-bigquery>=1.1,<1.12",
-    "dbt-snowflake>=1.1,<1.12",
+    "dbt-redshift>=1.1,<2.0",
+    "dbt-bigquery>=1.1,<2.0",
+    "dbt-snowflake>=1.1,<2.0",
     "redshift-connector>=2.0.910,<3",
     "pytest-dependency>=0.5.1,<0.7",
     "python-dotenv>=1.2.2,<2",
-    "pandas>=2.0,<3",
-    "snowflake-connector-python[pandas]>=3.0,<4.6",
+    "pandas>=2.0,<4",
+    "snowflake-connector-python[pandas]>=3.0,<4.8",
     "google-cloud-bigquery>2.34,<4",
-    "tox>=3.23.1,<4",
+    "tox>=3.23.1,<5",
 ]
 
 [build-system]
@@ -129,13 +129,28 @@ title_format = "## dbt-coves [{version}] - {project_date}"
 [tool.pytest.ini_options]
 markers = ["datafiles"]
 
-[tool.black]
-line-length = 100
-target-version=['py311', 'py312', 'py313', 'py314']
+# DCV-3932: ruff replaces black (format), isort (import sorting) and flake8
+# (lint), matching the datacoves repo's config. The defaults of `ruff format`
+# are black-compatible at line-length 88.
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+extend-exclude = [
+    "*_template.py",
+    "**/migrations/**",
+    "**/node_modules/**",
+]
 
-[tool.isort]
-known_third_party=["airflow", "black", "copier", "dbt", "dlt", "dotenv", "git", "google", "isort", "jinja2", "mixpanel", "pretty_errors", "pydantic", "pyfiglet", "pytest", "questionary", "redshift_connector", "requests", "rich", "ruamel", "slugify", "snowflake", "sqlalchemy", "typing_extensions", "yaml"]
-line_length=100
-multi_line_output=3
-include_trailing_comma=true
-profile="black"
+[tool.ruff.lint]
+# E/W (pycodestyle) + F (pyflakes) + C90 (mccabe) replicate flake8; I (isort)
+# replaces the isort hook; T10 (flake8-debugger) replaces the debug-statements
+# hook. E501 is delegated to the formatter (it wraps at line-length), matching
+# the old per-file E501 ignores. W503 has no ruff equivalent (omitted).
+select = ["E", "W", "F", "C90", "I", "T10"]
+ignore = ["E203", "E266", "E741", "E713", "E731", "C901", "E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"*_generator.py" = ["F541"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10

--- a/tests/blue_green_test.py
+++ b/tests/blue_green_test.py
@@ -65,9 +65,7 @@ def snowflake_connection(request):
     request.cls.warehouse = warehouse
     request.cls.schema = schema
     request.cls.production_database = database
-    request.cls.staging_database = (
-        f"{request.cls.production_database}_{DBT_COVES_SETTINGS.get('staging_suffix', 'staging')}"
-    )
+    request.cls.staging_database = f"{request.cls.production_database}_{DBT_COVES_SETTINGS.get('staging_suffix', 'staging')}"
 
     yield conn
 

--- a/tests/generate_docs_test.py
+++ b/tests/generate_docs_test.py
@@ -54,7 +54,13 @@ def test_generate_docs_merge_deferred_no_state(dbt_project_path):
     Test that runs `dbt-coves generate docs --merge-deferred`
     It's expected to break because no state was passed
     """
-    command = ["python", "../../dbt_coves/core/main.py", "generate", "docs", "--merge-deferred"]
+    command = [
+        "python",
+        "../../dbt_coves/core/main.py",
+        "generate",
+        "docs",
+        "--merge-deferred",
+    ]
     try:
         subprocess.check_output(command, cwd=dbt_project_path)
     except subprocess.CalledProcessError as e:

--- a/tests/generate_sources_test.py
+++ b/tests/generate_sources_test.py
@@ -83,14 +83,18 @@ def get_connector_redshift(host, user, password, database):
 def get_client_bigquery(sa_key, project_id):
     # Generate SA credentials file
     with open(
-        pathlib.Path(os.path.dirname(pathlib.Path(__file__).absolute()), "service_account.json"),
+        pathlib.Path(
+            os.path.dirname(pathlib.Path(__file__).absolute()), "service_account.json"
+        ),
         "w",
     ) as f:
         f.write(sa_key)
 
     # Get BigQuery Client
     credentials = service_account.Credentials.from_service_account_file(
-        pathlib.Path(os.path.dirname(pathlib.Path(__file__).absolute()), "service_account.json"),
+        pathlib.Path(
+            os.path.dirname(pathlib.Path(__file__).absolute()), "service_account.json"
+        ),
         scopes=["https://www.googleapis.com/auth/cloud-platform"],
     )
 
@@ -152,7 +156,9 @@ def get_cases(path_dir):
 
 # Check case folders
 cases_list = get_cases(
-    pathlib.Path(os.path.dirname(pathlib.Path(__file__).absolute()), "generate_sources_cases")
+    pathlib.Path(
+        os.path.dirname(pathlib.Path(__file__).absolute()), "generate_sources_cases"
+    )
 )
 
 # Generate data tests
@@ -271,7 +277,9 @@ def test_generate_data(input):
         client = get_client_bigquery(sa_key, project_id)
 
         # Generate data
-        query_job = client.query(f"CREATE SCHEMA IF NOT EXISTS `{project_id}.{schema}`;")
+        query_job = client.query(
+            f"CREATE SCHEMA IF NOT EXISTS `{project_id}.{schema}`;"
+        )
         query_job.result()
         assert query_job.errors is None
         with open(input["create_model_sql_file"], "r") as sql_file:
@@ -488,9 +496,13 @@ def test_check_models(input, expected):
         source_model_output = [line.replace("''", '""') for line in file_1.readlines()]
 
     with open(pathlib.Path(expected["source_model"]), "r") as file_2:
-        source_model_expected = [line.replace("''", '""') for line in file_2.readlines()]
+        source_model_expected = [
+            line.replace("''", '""') for line in file_2.readlines()
+        ]
 
-    diff_files = set(source_model_output).symmetric_difference(set(source_model_expected))
+    diff_files = set(source_model_output).symmetric_difference(
+        set(source_model_expected)
+    )
 
     assert len(list(diff_files)) == 0
 
@@ -542,9 +554,9 @@ def test_update_models(input):
         "sources.yml",
     )
     source_yml = yaml.load(source_path)
-    source_yml.get("sources")[0].get("tables")[0][
-        "description"
-    ] = "**[Read more](https://www.google.com/)**"
+    source_yml.get("sources")[0].get("tables")[0]["description"] = (
+        "**[Read more](https://www.google.com/)**"
+    )
     yaml.dump(source_yml, source_path)
 
     # Model
@@ -658,7 +670,9 @@ def test_check_descriptions(input, expected):
     with open(pathlib.Path(expected["updated_source_model"]), "r") as file_2:
         source_model_expected = [line.replace("'", '"') for line in file_2.readlines()]
 
-    diff_files = set(source_model_output).symmetric_difference(set(source_model_expected))
+    diff_files = set(source_model_output).symmetric_difference(
+        set(source_model_expected)
+    )
 
     assert len(list(diff_files)) == 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "dbt-coves"
-version = "1.11.2"
+version = "1.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "black" },
@@ -785,7 +785,6 @@ dependencies = [
 dev = [
     { name = "asciinema" },
     { name = "bumpversion" },
-    { name = "flake8" },
     { name = "ipdb" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -795,6 +794,7 @@ dev = [
     { name = "pytest-dictsdiff" },
     { name = "pytest-mock" },
     { name = "pytest-sugar" },
+    { name = "ruff" },
     { name = "sphinx-argparse" },
     { name = "sphinxcontrib-restbuilder" },
     { name = "towncrier" },
@@ -820,17 +820,17 @@ requires-dist = [
     { name = "black", specifier = ">=25,<27" },
     { name = "copier", specifier = ">=9.0.0" },
     { name = "db-dtypes", specifier = ">=1.0.5,<2" },
-    { name = "dbt-core", specifier = ">=1.1,<1.12" },
+    { name = "dbt-core", specifier = ">=1.1,<2.0" },
     { name = "dlt", extras = ["redshift"], specifier = ">=1.0" },
     { name = "enlighten", specifier = ">=1.12.4,<2" },
     { name = "gitpython", specifier = ">=3.1.31,<4" },
     { name = "isort", specifier = ">=5.12.0,<9" },
     { name = "jinja2", specifier = ">2.11.2" },
     { name = "jinja2-env", specifier = ">=0.1.3,<0.2" },
-    { name = "mixpanel", specifier = ">=4.10.0,<5" },
+    { name = "mixpanel", specifier = ">=4.10.0,<6" },
     { name = "packaging", specifier = ">=20.8" },
     { name = "pretty-errors", specifier = ">=1.2.19,<2" },
-    { name = "prompt-toolkit", specifier = "==3.0.51" },
+    { name = "prompt-toolkit", specifier = "==3.0.52" },
     { name = "psycopg2-binary", specifier = ">=2.9.9,<3" },
     { name = "pydantic", specifier = ">=1.8" },
     { name = "python-slugify", specifier = "<9.0.0" },
@@ -838,7 +838,7 @@ requires-dist = [
     { name = "questionary", specifier = "==2.1.1" },
     { name = "rich", specifier = ">=10.4" },
     { name = "ruamel-yaml", specifier = ">=0.17.21,<0.20" },
-    { name = "snowflake-connector-python", specifier = ">=3.12.1,<4.6" },
+    { name = "snowflake-connector-python", specifier = ">=3.12.1,<4.8" },
     { name = "sqlalchemy", specifier = ">=1.4,<3" },
 ]
 
@@ -846,34 +846,34 @@ requires-dist = [
 dev = [
     { name = "asciinema", specifier = ">=2.0.2,<3" },
     { name = "bumpversion", specifier = ">=0.6.0,<0.7" },
-    { name = "flake8", specifier = ">=7.1.0,<8" },
     { name = "ipdb", specifier = ">=0.13.9,<0.14" },
-    { name = "mypy", specifier = ">=0.991,<2.2" },
+    { name = "mypy", specifier = ">=0.991,<2.4" },
     { name = "pre-commit", specifier = ">=3.5.0,<5" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "pytest-cov", specifier = ">=4.0.0,<8" },
     { name = "pytest-datafiles", specifier = ">=2.0,<4" },
     { name = "pytest-dictsdiff", specifier = ">=0.5.8,<0.6" },
     { name = "pytest-mock", specifier = ">=3.6.1,<4" },
-    { name = "pytest-sugar", specifier = ">=0.9.4,<0.10" },
-    { name = "sphinx-argparse", specifier = ">=0.4.0,<0.5" },
+    { name = "pytest-sugar", specifier = ">=0.9.4,<1.2" },
+    { name = "ruff", specifier = "==0.15.19" },
+    { name = "sphinx-argparse", specifier = ">=0.4.0,<0.7" },
     { name = "sphinxcontrib-restbuilder", specifier = ">=0.3,<0.4" },
-    { name = "towncrier", specifier = ">=22.12.0,<23" },
+    { name = "towncrier", specifier = ">=22.12.0,<26" },
     { name = "types-python-slugify", specifier = ">=8.0.0.0,<9" },
     { name = "types-pyyaml", specifier = ">=5.4.1,<7" },
     { name = "types-requests", specifier = ">=2.28.11.5,<3" },
 ]
 test = [
-    { name = "dbt-bigquery", specifier = ">=1.1,<1.12" },
-    { name = "dbt-redshift", specifier = ">=1.1,<1.11" },
-    { name = "dbt-snowflake", specifier = ">=1.1,<1.12" },
+    { name = "dbt-bigquery", specifier = ">=1.1,<2.0" },
+    { name = "dbt-redshift", specifier = ">=1.1,<2.0" },
+    { name = "dbt-snowflake", specifier = ">=1.1,<2.0" },
     { name = "google-cloud-bigquery", specifier = ">2.34,<4" },
-    { name = "pandas", specifier = ">=2.0,<3" },
+    { name = "pandas", specifier = ">=2.0,<4" },
     { name = "pytest-dependency", specifier = ">=0.5.1,<0.7" },
     { name = "python-dotenv", specifier = ">=1.2.2,<2" },
     { name = "redshift-connector", specifier = ">=2.0.910,<3" },
-    { name = "snowflake-connector-python", extras = ["pandas"], specifier = ">=3.0,<4.6" },
-    { name = "tox", specifier = ">=3.23.1,<4" },
+    { name = "snowflake-connector-python", extras = ["pandas"], specifier = ">=3.0,<4.8" },
+    { name = "tox", specifier = ">=3.23.1,<5" },
 ]
 
 [[package]]
@@ -1141,20 +1141,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
-]
-
-[[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
 ]
 
 [[package]]
@@ -2310,15 +2296,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2929,14 +2906,14 @@ wheels = [
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.51"
+version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/6e/9d084c929dfe9e3bfe0c6a47e31f78a25c54627d64a66e884a8bf5474f1c/prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed", size = 428940, upload-time = "2025-04-15T09:18:47.731Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/4f/5249960887b1fbe561d9ff265496d170b55a735b76724f10ef19f9e40716/prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07", size = 387810, upload-time = "2025-04-15T09:18:44.753Z" },
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -3145,15 +3122,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3291,15 +3259,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/0d/455cb39f0d5a914412b57c55c6b16977c61a5ac74b615eea4fb0dc54e329/pydata-google-auth-1.9.1.tar.gz", hash = "sha256:0a51ce41c601ca0bc69b8795bf58bedff74b4a6a007c9106c7cbcdec00eaced2", size = 29814, upload-time = "2025-01-23T21:04:40.875Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/cb/cdeaba62aa3c48f0d8834afb82b4a21463cd83df34fe01f9daa89a08ec6c/pydata_google_auth-1.9.1-py2.py3-none-any.whl", hash = "sha256:75ffce5d106e34b717b31844c1639ea505b7d9550dc23b96fb6c20d086b53fa3", size = 15552, upload-time = "2025-01-23T21:04:38.97Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
 ]
 
 [[package]]
@@ -3838,6 +3797,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/e6/15800dfde183a1a106594016c912b4c12d050a301989d1aca6cb63759fe8/ruff-0.15.19.tar.gz", hash = "sha256:edc27f7172a93b32b102687009d6a588508815072141543ae603a8b9b0823063", size = 4772071, upload-time = "2026-06-24T01:10:46.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/4c/9ded7626c39a0440c575bf69e2bf500d443388272c842662c59852ee7fcd/ruff-0.15.19-py3-none-linux_armv6l.whl", hash = "sha256:922d1eb283161564759bd49f507e91dc6112c15da8bd5b84ed714e086243cf86", size = 10950859, upload-time = "2026-06-24T01:10:38.491Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ef/c211505ece1d00ef493d58e54e3b6383c946a21e9874774eb531f2512cf3/ruff-0.15.19-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4d190d8f62a0b94aba8f721116538a9ee29b1e74d26650846ba9b99f0ae21c40", size = 11294529, upload-time = "2026-06-24T01:10:36.481Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/78d462e7d39968e58094dc57be7d09ffb14ce37da5b68ed70338a35a1f21/ruff-0.15.19-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5a2c86ba6870dd415a9d9eb8be94d7924ebec6a26ffc7958ec7ca29d4bff967d", size = 10641416, upload-time = "2026-06-24T01:10:48.923Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c4/5cb66cfd1f865d5cca908b86c93ac785e7f572193d3c7426079ca6643e24/ruff-0.15.19-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82b432bc087264aea70fd25ac198918b70bd9e2aa0db4297b0bb91bbfbbc63ce", size = 11015582, upload-time = "2026-06-24T01:10:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9f/8ecfaec10cf5eecd28fbc00ff4fb867db90a1be54bf3d39ebf93f893cd52/ruff-0.15.19-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8530a09d03b3a8c994f8b559a7dcdabc690bcd3f78ef276c38c83166798ebf56", size = 10744059, upload-time = "2026-06-24T01:10:32.48Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6b/983249d04562bc2d590edd75f32455cdb473affb3ba4bc8d883e939c697d/ruff-0.15.19-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87bf21fb3875fe69f0eacc825411657e2e85589cce633c35c0adf1113649c62b", size = 11568461, upload-time = "2026-06-24T01:10:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/39/bc7794f127b18f492a3b4ee82bba5a900c985ff13b72b46f46e3c171ba34/ruff-0.15.19-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9b229cb3ef56ecc2c1c8ebeca64b7a7740ccaef40a9eb097e78dde5a8560b83", size = 12429690, upload-time = "2026-06-24T01:10:40.638Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/3b/0de6859e698ed11c8a49e765196c8d333599b6a546c0715df39b6ba1aa2e/ruff-0.15.19-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6c754515be7b76afe6e7e62df7776709571bcfc1631183828afcf3bafa869e3", size = 11693067, upload-time = "2026-06-24T01:10:25.681Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3d/0b1f30f84bee9ae6ae8d349c2ba8b6f4b040966744efdd3acc804ae7c024/ruff-0.15.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a498f82e0f4d8904c4e0aea5139cdfac1f39d19a3c51d491292f63a36e83b2e", size = 11616911, upload-time = "2026-06-24T01:10:44.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/eb/c90bd3dfc12eed9032c2c1bfe05105b93a1b2c8bce555db6308315b853ce/ruff-0.15.19-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:d48caa34488fb521fd0ef4aea2b0e8fe758298df044138f0d67b687a6a0d07ed", size = 11649343, upload-time = "2026-06-24T01:10:23.472Z" },
+    { url = "https://files.pythonhosted.org/packages/82/91/01caa13602a2f12fae5edbe8caf78b3c1e6db1293132aee6959eecce095c/ruff-0.15.19-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4171b6613effa9363cd46dd4f75bd1827b6d1b946b5e278ed0c600d305379445", size = 10977610, upload-time = "2026-06-24T01:10:50.892Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/acb817922feab9ecbb3201377d4dbe7a25f1395e46545820061973f03468/ruff-0.15.19-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:27c15b2a241dd4d995557949a094fe78b8ad99122a38ccae1595849bcc947b3f", size = 10744900, upload-time = "2026-06-24T01:10:42.726Z" },
+    { url = "https://files.pythonhosted.org/packages/84/bc/5c8ca46b8a7a3f2b16cfbec88721d772b1c93912904e8f8c2e49470fea63/ruff-0.15.19-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ed03b7862d68f0a8771d50ee129980cbf1b113f96e250b73954bc292f689e0bb", size = 11293560, upload-time = "2026-06-24T01:10:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e0/4a888cbe4d5523b3f77a2b1fa043f46cfeba1b32eac35dcfadee0578fa8a/ruff-0.15.19-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:08143f0685ae278b30727ea72e90c61e5bd9c31b91aac4f5bb989538f73d24b8", size = 11696533, upload-time = "2026-06-24T01:10:53.046Z" },
+    { url = "https://files.pythonhosted.org/packages/98/43/c34b2fcd79262a85161764a97aaca89c3e4f574340ab61430cefa2bdd2c1/ruff-0.15.19-py3-none-win32.whl", hash = "sha256:8f47f0f92952af2557212bb10cf3e695cd4cf28b2c6e42cdb18ec6c9ebfa19da", size = 10986299, upload-time = "2026-06-24T01:10:55.185Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e8/15fd23e02b2442b56b2026b455977bc3057aa34b26e6323d1e99e8531a9f/ruff-0.15.19-py3-none-win_amd64.whl", hash = "sha256:efeca47ee3f9d4a7162655a3b8e6ee4a878646044233978d4d2c1ff8cdd914f0", size = 12123473, upload-time = "2026-06-24T01:10:27.74Z" },
+    { url = "https://files.pythonhosted.org/packages/30/66/9a73695e31eaee04f35d8475998bf8ab354465f9c638936d76111603dcc5/ruff-0.15.19-py3-none-win_arm64.whl", hash = "sha256:6c6b607466e47349332eb1d9be52fb1467423fc07c217341af41cd0f3f0573be", size = 11376779, upload-time = "2026-06-24T01:10:34.465Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This includes support for all dbt versions <2.0.

Additionally:
- switch to `ruff` for formatting and linting (this project, still uses flake8/black/isort for DAG generation)
- address all open Dependabot items